### PR TITLE
adding fields to support guest, segment and booking types

### DIFF
--- a/Sift/Schema/ComplexTypes/booking.json
+++ b/Sift/Schema/ComplexTypes/booking.json
@@ -1,0 +1,61 @@
+﻿{
+    "$schema": "http://json-schema.org/draft-04/schema",
+    "title": "Booking",
+    "type": "object",
+    "required": [ "$booking_type" ],
+    "properties": {
+        "$booking_type": {
+            "type": [ "string", "null" ]
+        },
+        "$title": {
+            "type": [ "string", "null" ]
+        },
+        "$start_time": {
+            "type": [ "integer", "null" ]
+        },
+        "$end_time": {
+            "type": [ "integer", "null" ]
+        },
+        "$price": {
+            "type": [ "integer", "null" ]
+        },
+        "$currency_code": {
+            "type": [ "string", "null" ]
+        },
+        "$quantity": {
+            "type": [ "integer", "null" ]
+        },
+        "$guests": {
+            "type": [ "array", "null" ],
+            "items": { "$ref": "guest.json" }
+        },
+        "$segments": {
+            "type": [ "array", "null" ],
+            "items": { "$ref": "segment.json" }
+        },
+        "$room_type": {
+            "type": [ "string", "null" ]
+        },
+        "$event_id": {
+            "type": [ "string", "null" ]
+        },
+        "$venue_id": {
+            "type": [ "string", "null" ]
+        },
+        "$location": {
+            "oneOf": [
+                { "$ref": "address.json" },
+                { "type": "null" }
+            ]
+        },
+        "$category": {
+            "type": [ "string", "null" ]
+        },
+        "$tags": {
+            "type": [ "array", "null" ],
+            "items": {
+                "type": "string"
+            }
+        }
+    }
+}

--- a/Sift/Schema/ComplexTypes/booking.json
+++ b/Sift/Schema/ComplexTypes/booking.json
@@ -11,13 +11,16 @@
             "type": [ "string", "null" ]
         },
         "$start_time": {
-            "type": [ "integer", "null" ]
+            "type": [ "integer", "null" ],
+            "format": "long"
         },
         "$end_time": {
-            "type": [ "integer", "null" ]
+            "type": [ "integer", "null" ],
+            "format": "long"
         },
         "$price": {
-            "type": [ "integer", "null" ]
+            "type": [ "integer", "null" ],
+            "format": "long"
         },
         "$currency_code": {
             "type": [ "string", "null" ]

--- a/Sift/Schema/ComplexTypes/guest.json
+++ b/Sift/Schema/ComplexTypes/guest.json
@@ -1,0 +1,25 @@
+﻿{
+    "$schema": "http://json-schema.org/draft-04/schema",
+    "title": "Guest",
+    "type": "object",
+    "properties": {
+        "$name": {
+            "type": [ "string", "null" ]
+        },
+        "$email": {
+            "type": [ "string", "null" ]
+        },
+        "$phone": {
+            "type": [ "string", "null" ]
+        },
+        "$loyalty_program": {
+            "type": [ "string", "null" ]
+        },
+        "$loyalty_program_id": {
+            "type": [ "string", "null" ]
+        },
+        "$birth_date": {
+            "type": [ "string", "null" ]
+        }
+    }
+}

--- a/Sift/Schema/ComplexTypes/segment.json
+++ b/Sift/Schema/ComplexTypes/segment.json
@@ -1,0 +1,37 @@
+﻿{
+    "$schema": "http://json-schema.org/draft-04/schema",
+    "title": "Segment",
+    "type": "object",
+    "properties": {
+        "$start_time": {
+            "type": [ "integer", "null" ]
+        },
+        "$end_time": {
+            "type": [ "integer", "null" ]
+        },
+        "$vessel_number": {
+            "type": [ "string", "null" ]
+        },
+        "$departure_airport_code": {
+            "type": [ "string", "null" ]
+        },
+        "$arrival_airport_code": {
+            "type": [ "string", "null" ]
+        },
+        "$fare_class": {
+            "type": [ "string", "null" ]
+        },
+        "$departure_address": {
+            "oneOf": [
+                { "$ref": "address.json" },
+                { "type": "null" }
+            ]
+        },
+        "$arrival_address": {
+            "oneOf": [
+                { "$ref": "address.json" },
+                { "type": "null" }
+            ]
+        }
+    }
+}

--- a/Sift/Schema/ComplexTypes/segment.json
+++ b/Sift/Schema/ComplexTypes/segment.json
@@ -4,10 +4,12 @@
     "type": "object",
     "properties": {
         "$start_time": {
-            "type": [ "integer", "null" ]
+            "type": [ "integer", "null" ],
+            "format": "long"
         },
         "$end_time": {
-            "type": [ "integer", "null" ]
+            "type": [ "integer", "null" ],
+            "format": "long"
         },
         "$vessel_number": {
             "type": [ "string", "null" ]

--- a/Sift/Schema/create_order.json
+++ b/Sift/Schema/create_order.json
@@ -11,6 +11,12 @@
     "$user_id": {
       "type": [ "string", "null" ]
     },
+    "$time": {
+        "type": [ "integer", "null" ]
+    },
+    "$ip": {
+        "type": [ "string", "null" ]
+    },
     "$session_id": {
       "type": [ "string", "null" ]
     },
@@ -49,6 +55,10 @@
     "$items": {
       "type": [ "array", "null" ],
       "items": { "$ref": "ComplexTypes/item.json" }
+    },
+    "$bookings": {
+        "type": [ "array", "null" ],
+        "items": { "$ref": "ComplexTypes/booking.json" }
     },
     "$seller_user_id": {
       "type": [ "string", "null" ]

--- a/Sift/Schema/create_order.json
+++ b/Sift/Schema/create_order.json
@@ -11,12 +11,6 @@
     "$user_id": {
       "type": [ "string", "null" ]
     },
-    "$time": {
-        "type": [ "integer", "null" ]
-    },
-    "$ip": {
-        "type": [ "string", "null" ]
-    },
     "$session_id": {
       "type": [ "string", "null" ]
     },

--- a/Sift/Schema/update_order.json
+++ b/Sift/Schema/update_order.json
@@ -11,6 +11,12 @@
     "$user_id": {
       "type": [ "string", "null" ]
     },
+    "$time": {
+        "type": [ "integer", "null" ]
+    },
+    "$ip": {
+        "type": [ "string", "null" ]
+    },
     "$session_id": {
       "type": [ "string", "null" ]
     },
@@ -49,6 +55,10 @@
     "$items": {
       "type": [ "array", "null" ],
       "items": { "$ref": "ComplexTypes/item.json" }
+    },
+    "$bookings": {
+        "type": [ "array", "null" ],
+        "items": { "$ref": "ComplexTypes/booking.json" }
     },
     "$seller_user_id": {
       "type": [ "string", "null" ]

--- a/Sift/Schema/update_order.json
+++ b/Sift/Schema/update_order.json
@@ -11,12 +11,6 @@
     "$user_id": {
       "type": [ "string", "null" ]
     },
-    "$time": {
-        "type": [ "integer", "null" ]
-    },
-    "$ip": {
-        "type": [ "string", "null" ]
-    },
     "$session_id": {
       "type": [ "string", "null" ]
     },

--- a/Test/Test.cs
+++ b/Test/Test.cs
@@ -136,7 +136,7 @@ namespace Test
             // Augment with custom fields
             createOrder.AddField("foo", "bar");
             Assert.Equal("{\"$type\":\"$create_order\",\"$user_id\":\"test_dotnet_booking_with_all_fields\"," +
-                         "\"$time\":1518834678,\"$session_id\":\"gigtleqddo84l8cm15qe4il\"," +
+                         "\"$session_id\":\"gigtleqddo84l8cm15qe4il\"," +
                          "\"$order_id\":\"oid\",\"$user_email\":\"bill@gmail.com\",\"$amount\":1000000000000," +
                          "\"$currency_code\":\"USD\",\"$billing_address\":{\"$name\":\"gary\"," +
                          "\"$city\":\"san francisco\"},\"$bookings\":[{\"$booking_type\":\"$flight\"," +

--- a/Test/Test.cs
+++ b/Test/Test.cs
@@ -2,6 +2,7 @@ using System;
 using Xunit;
 using Sift;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Text;
 
 namespace Test
@@ -30,15 +31,97 @@ namespace Test
 
         }
 
-        [Fact]
+        [Fact
         public void TestEventRequest()
         {
-            var createOrder = new Sift.CreateOrder
+            var createOrder = new CreateOrder
             {
-                user_id = "gary",
+                user_id = "test_dotnet_booking_with_all_fields",
                 order_id = "oid",
-                amount = 1000000000000L,
+                amount = 1000000,
                 currency_code = "USD",
+                time = 1518834678,
+                session_id = "gigtleqddo84l8cm15qe4il",
+                user_email = "bill@gmail.com",
+                bookings = new ObservableCollection<Booking>()
+                {
+                    new Booking()
+                    {
+                        booking_type = "$flight",
+                        title = "SFO - LAS, 2 Adults",
+                        start_time= 2038412903,
+                        end_time= 2038412903,
+                        price = 49900000,
+                        currency_code = "USD",
+                        quantity = 1,
+                        venue_id = "venue-123",
+                        event_id = "event-123",
+                        room_type = "deluxe",
+                        category = "pop",
+                        guests = new ObservableCollection<Guest>()
+                        {
+                            new Guest()
+                            {
+                                name = "John Doe",
+                                birth_date = "1985-01-19",
+                                loyalty_program = "skymiles",
+                                loyalty_program_id = "PSOV34DF",
+                                phone = "1-415-555-6040",
+                                email = "jdoe@domain.com"
+                            },
+                            new Guest()
+                            {
+                                name = "John Doe"
+                            }
+                        },
+                        segments = new ObservableCollection<Segment>()
+                        {
+                            new Segment()
+                            {
+                                departure_address = new Address
+                                {
+                                    name = "Bill Jones",
+                                    phone =  "1-415-555-6040",
+                                    address_1 = "2100 Main Street",
+                                    address_2 = "Apt 3B",
+                                    city = "New London",
+                                    region = "New Hampshire",
+                                    country = "US",
+                                    zipcode = "03257"
+                                },
+                                arrival_address = new Address
+                                {
+                                    name = "Bill Jones",
+                                    phone =  "1-415-555-6040",
+                                    address_1 = "2100 Main Street",
+                                    address_2 = "Apt 3B",
+                                    city = "New London",
+                                    region = "New Hampshire",
+                                    country = "US",
+                                    zipcode = "03257"
+                                },
+                                start_time = 2038412903,
+                                end_time = 2038412903,
+                                vessel_number = "LH454",
+                                fare_class = "Premium Economy",
+                                departure_airport_code = "SFO",
+                                arrival_airport_code = "LAS"
+                            }
+                        },
+                        location = new Address
+                        {
+                            name = "Bill Jones",
+                            phone =  "1-415-555-6040",
+                            address_1 = "2100 Main Street",
+                            address_2 = "Apt 3B",
+                            city = "New London",
+                            region = "New Hampshire",
+                            country = "US",
+                            zipcode = "03257"
+                        },
+                        tags = new ObservableCollection<string>() { "tag-123", "tag-321" }
+                    }
+                },
                 billing_address = new Address
                 {
                     name = "gary",
@@ -46,20 +129,35 @@ namespace Test
                 },
                 app = new App
                 {
-                    app_name = "app",
+                    app_name = "my app",
                     app_version = "1.0"
                 }
             };
 
             // Augment with custom fields
             createOrder.AddField("foo", "bar");
-
-            Assert.Equal("{\"$type\":\"$create_order\",\"$user_id\":\"gary\"," +
-                         "\"$order_id\":\"oid\",\"$amount\":1000000000000,\"$currency_code\":" +
-                         "\"USD\",\"$billing_address\":{\"$name\":\"gary\",\"$city\":" +
-                         "\"san francisco\"},\"$app\":{\"$app_name\":\"app\"," +
-                         "\"$app_version\":\"1.0\"},\"foo\":\"bar\"}",
+            Assert.Equal("{\"$type\":\"$create_order\",\"$user_id\":\"test_dotnet_booking_with_all_fields\"," +
+                         "\"$time\":1518834678,\"$session_id\":\"gigtleqddo84l8cm15qe4il\"," +
+                         "\"$order_id\":\"oid\",\"$user_email\":\"bill@gmail.com\",\"$amount\":1000000000000," +
+                         "\"$currency_code\":\"USD\",\"$billing_address\":{\"$name\":\"gary\"," +
+                         "\"$city\":\"san francisco\"},\"$bookings\":[{\"$booking_type\":\"$flight\"," +
+                         "\"$title\":\"SFO - LAS, 2 Adults\",\"$start_time\":2038412903,\"$end_time\":2038412903," +
+                         "\"$price\":49900000,\"$currency_code\":\"USD\",\"$quantity\":1,\"$guests\":[{\"$name\":\"John Doe\"," +
+                         "\"$email\":\"jdoe@domain.com\",\"$phone\":\"1-415-555-6040\",\"$loyalty_program\":\"skymiles\"," +
+                         "\"$loyalty_program_id\":\"PSOV34DF\",\"$birth_date\":\"1985-01-19\"},{\"$name\":\"John Doe\"}]," +
+                         "\"$segments\":[{\"$start_time\":203841290300,\"$end_time\":2038412903,\"$vessel_number\":\"LH454\"," +
+                         "\"$departure_airport_code\":\"SFO\",\"$arrival_airport_code\":\"LAS\",\"$fare_class\":\"Premium Economy\"," +
+                         "\"$departure_address\":{\"$name\":\"Bill Jones\",\"$address_1\":\"2100 Main Street\",\"$address_2\":\"Apt 3B\"," +
+                         "\"$city\":\"New London\",\"$region\":\"New Hampshire\",\"$country\":\"US\",\"$zipcode\":\"03257\"," +
+                         "\"$phone\":\"1-415-555-6040\"},\"$arrival_address\":{\"$name\":\"Bill Jones\",\"$address_1\":\"2100 Main Street\"," +
+                         "\"$address_2\":\"Apt 3B\",\"$city\":\"New London\",\"$region\":\"New Hampshire\",\"$country\":\"US\"," +
+                         "\"$zipcode\":\"03257\",\"$phone\":\"1-415-555-6040\"}}],\"$room_type\":\"deluxe\",\"$event_id\":\"event-123\"," +
+                         "\"$venue_id\":\"venue-123\",\"$location\":{\"$name\":\"Bill Jones\",\"$address_1\":\"2100 Main Street\"," +
+                         "\"$address_2\":\"Apt 3B\",\"$city\":\"New London\",\"$region\":\"New Hampshire\",\"$country\":\"US\"," +
+                         "\"$zipcode\":\"03257\",\"$phone\":\"1-415-555-6040\"},\"$category\":\"pop\",\"$tags\":[\"tag-123\",\"tag-321\"]}]," +
+                         "\"$app\":{\"$app_name\":\"my app\",\"$app_version\":\"1.0\"},\"foo\":\"bar\"}",
                          createOrder.ToJson());
+
 
             EventRequest eventRequest = new EventRequest
             {

--- a/Test/Test.cs
+++ b/Test/Test.cs
@@ -31,7 +31,7 @@ namespace Test
 
         }
 
-        [Fact
+        [Fact]
         public void TestEventRequest()
         {
             var createOrder = new CreateOrder

--- a/Test/Test.cs
+++ b/Test/Test.cs
@@ -38,7 +38,7 @@ namespace Test
             {
                 user_id = "test_dotnet_booking_with_all_fields",
                 order_id = "oid",
-                amount = 1000000,
+                amount = 1000000000000L,
                 currency_code = "USD",
                 time = 1518834678,
                 session_id = "gigtleqddo84l8cm15qe4il",
@@ -100,7 +100,7 @@ namespace Test
                                     country = "US",
                                     zipcode = "03257"
                                 },
-                                start_time = 2038412903,
+                                start_time = 203841290300L,
                                 end_time = 2038412903,
                                 vessel_number = "LH454",
                                 fare_class = "Premium Economy",

--- a/Test/Test.cs
+++ b/Test/Test.cs
@@ -40,7 +40,6 @@ namespace Test
                 order_id = "oid",
                 amount = 1000000000000L,
                 currency_code = "USD",
-                time = 1518834678,
                 session_id = "gigtleqddo84l8cm15qe4il",
                 user_email = "bill@gmail.com",
                 bookings = new ObservableCollection<Booking>()


### PR DESCRIPTION
**Purpose**
Capture travel and ticketing specific data by providing additional fields in the API.

**Technical overview**
Add support for the new booking fields (`$segment`, `$guest` and `$booking`) in `$create_order` and `$update_order` events

**Testing Plan**
Updated unit tests
Send sample events using Client and verify the changes on the console

**Deployment**
Publish the package using NuGet