### PR TITLE
Use long for amounts and times

### DIFF
--- a/Sift/Schema/ComplexTypes/credit_point.json
+++ b/Sift/Schema/ComplexTypes/credit_point.json
@@ -4,7 +4,8 @@
   "type": "object",
   "properties": {
     "$amount": {
-      "type": [ "integer", "null" ]
+      "type": [ "integer", "null" ],
+      "format": "long"
     },
     "$credit_point_type": {
       "type": [ "string", "null" ]

--- a/Sift/Schema/ComplexTypes/discount.json
+++ b/Sift/Schema/ComplexTypes/discount.json
@@ -7,13 +7,15 @@
       "type": [ "number", "null" ]
     },
     "$amount": {
-      "type": [ "integer", "null" ]
+      "type": [ "integer", "null" ],
+      "format": "long"
     },
     "$currency_code": {
       "type": [ "string", "null" ]
     },
     "$minimum_purchase_amount": {
-      "type": [ "integer", "null" ]
+      "type": [ "integer", "null" ],
+      "format": "long"
     },
   }
 }

--- a/Sift/Schema/ComplexTypes/item.json
+++ b/Sift/Schema/ComplexTypes/item.json
@@ -10,7 +10,8 @@
       "type": [ "string", "null" ]
     },
     "$price": {
-      "type": [ "integer", "null" ]
+      "type": [ "integer", "null" ],
+      "format": "long"
     },
     "$currency_code": {
       "type": [ "string", "null" ]

--- a/Sift/Schema/ComplexTypes/listing.json
+++ b/Sift/Schema/ComplexTypes/listing.json
@@ -28,7 +28,8 @@
       "items": { "$ref": "image.json" }
     },
     "$expiration_time": {
-      "type": [ "integer", "null" ]
+      "type": [ "integer", "null" ],
+      "format": "long"
     }
   }
 }

--- a/Sift/Schema/ComplexTypes/post.json
+++ b/Sift/Schema/ComplexTypes/post.json
@@ -28,7 +28,8 @@
       "items": { "$ref": "image.json" }
     },
     "$expiration_time": {
-      "type": [ "integer", "null" ]
+      "type": [ "integer", "null" ],
+      "format": "long"
     }
   }
 }

--- a/Sift/Schema/create_order.json
+++ b/Sift/Schema/create_order.json
@@ -21,7 +21,8 @@
       "type": [ "string", "null" ]
     },
     "$amount": {
-      "type": ["integer", "null"]
+      "type": ["integer", "null"],
+      "format": "long"
     },
     "$currency_code": {
       "type": [ "string", "null" ]

--- a/Sift/Schema/transaction.json
+++ b/Sift/Schema/transaction.json
@@ -24,7 +24,8 @@
       "type": [ "string", "null" ]
     },
     "$amount": {
-      "type": ["integer", "null"]
+      "type": ["integer", "null"],
+      "format": "long"
     },
     "$currency_code": {
       "type": [ "string", "null" ]

--- a/Sift/Schema/update_order.json
+++ b/Sift/Schema/update_order.json
@@ -21,7 +21,8 @@
       "type": [ "string", "null" ]
     },
     "$amount": {
-      "type": ["integer", "null"]
+      "type": ["integer", "null"],
+      "format": "long"
     },
     "$currency_code": {
       "type": [ "string", "null" ]

--- a/Test/Test.cs
+++ b/Test/Test.cs
@@ -37,7 +37,7 @@ namespace Test
             {
                 user_id = "gary",
                 order_id = "oid",
-                amount = 1000000,
+                amount = 1000000000000L,
                 currency_code = "USD",
                 billing_address = new Address
                 {
@@ -55,7 +55,7 @@ namespace Test
             createOrder.AddField("foo", "bar");
 
             Assert.Equal("{\"$type\":\"$create_order\",\"$user_id\":\"gary\"," +
-                         "\"$order_id\":\"oid\",\"$amount\":1000000,\"$currency_code\":" +
+                         "\"$order_id\":\"oid\",\"$amount\":1000000000000,\"$currency_code\":" +
                          "\"USD\",\"$billing_address\":{\"$name\":\"gary\",\"$city\":" +
                          "\"san francisco\"},\"$app\":{\"$app_name\":\"app\"," +
                          "\"$app_version\":\"1.0\"},\"foo\":\"bar\"}",


### PR DESCRIPTION
There's a bug in our schemas where some integer values that can have a large range of values should be longs. It looks like the way to [make integer fields longs](https://github.com/RicoSuter/NJsonSchema/wiki/JsonSchemaGenerator#custom-type-and-format-for-class) is to add `"format": "long"` to the schema.