### PR TITLE
adding support for ordered_from, brand_name, site_* top level fields, and *_language fields in browser and app complex fields

### DIFF
--- a/Sift/Schema/ComplexTypes/app.json
+++ b/Sift/Schema/ComplexTypes/app.json
@@ -23,6 +23,9 @@
     },
     "$app_version": {
       "type": [ "string", "null" ]
+    },
+    "$client_language": {
+      "type": [ "string", "null" ]
     }
   }
 }

--- a/Sift/Schema/ComplexTypes/browser.json
+++ b/Sift/Schema/ComplexTypes/browser.json
@@ -5,6 +5,12 @@
   "properties": {
     "$user_agent": {
       "type": [ "string", "null" ]
+    },
+    "$accept_language": {
+      "type": [ "string", "null" ]
+    },
+    "$content_language": {
+      "type": [ "string", "null" ]
     }
   }
 }

--- a/Sift/Schema/ComplexTypes/ordered_from.json
+++ b/Sift/Schema/ComplexTypes/ordered_from.json
@@ -1,0 +1,16 @@
+﻿{
+  "$schema": "http://json-schema.org/draft-04/schema",
+  "title": "OrderedFrom",
+  "type": "object",
+  "properties": {
+    "$store_id": {
+      "type": [ "string", "null" ]
+    },
+    "$store_address": {
+      "oneOf": [
+        { "$ref": "address.json" },
+        { "type": "null" }
+      ]
+    }
+  }
+}

--- a/Sift/Schema/add_item_to_cart.json
+++ b/Sift/Schema/add_item_to_cart.json
@@ -31,6 +31,15 @@
         { "$ref": "ComplexTypes/browser.json" },
         { "type": "null" }
       ]
+    },
+    "$brand_name": {
+      "type": [ "string", "null" ]
+    },
+    "$site_country": {
+      "type": [ "string", "null" ]
+    },
+    "$site_domain": {
+      "type": [ "string", "null" ]
     }
   }
 }

--- a/Sift/Schema/add_promotion.json
+++ b/Sift/Schema/add_promotion.json
@@ -29,6 +29,15 @@
         { "$ref": "ComplexTypes/browser.json" },
         { "type": "null" }
       ]
+    },
+    "$brand_name": {
+      "type": [ "string", "null" ]
+    },
+    "$site_country": {
+      "type": [ "string", "null" ]
+    },
+    "$site_domain": {
+      "type": [ "string", "null" ]
     }
   }
 }

--- a/Sift/Schema/content_status.json
+++ b/Sift/Schema/content_status.json
@@ -31,6 +31,15 @@
         { "$ref": "ComplexTypes/browser.json" },
         { "type": "null" }
       ]
+    },
+    "$brand_name": {
+      "type": [ "string", "null" ]
+    },
+    "$site_country": {
+      "type": [ "string", "null" ]
+    },
+    "$site_domain": {
+      "type": [ "string", "null" ]
     }
   }
 }

--- a/Sift/Schema/create_account.json
+++ b/Sift/Schema/create_account.json
@@ -60,6 +60,15 @@
         { "$ref": "ComplexTypes/browser.json" },
         { "type": "null" }
       ]
+    },
+    "$brand_name": {
+      "type": [ "string", "null" ]
+    },
+    "$site_country": {
+      "type": [ "string", "null" ]
+    },
+    "$site_domain": {
+      "type": [ "string", "null" ]
     }
   }
 }

--- a/Sift/Schema/create_content.json
+++ b/Sift/Schema/create_content.json
@@ -70,6 +70,15 @@
         { "$ref": "ComplexTypes/browser.json" },
         { "type": "null" }
       ]
+    },
+    "$brand_name": {
+      "type": [ "string", "null" ]
+    },
+    "$site_country": {
+      "type": [ "string", "null" ]
+    },
+    "$site_domain": {
+      "type": [ "string", "null" ]
     }
   }
 }

--- a/Sift/Schema/create_order.json
+++ b/Sift/Schema/create_order.json
@@ -75,6 +75,21 @@
         { "$ref": "ComplexTypes/browser.json" },
         { "type": "null" }
       ]
+    },
+    "$brand_name": {
+      "type": [ "string", "null" ]
+    },
+    "$site_country": {
+      "type": [ "string", "null" ]
+    },
+    "$site_domain": {
+      "type": [ "string", "null" ]
+    },
+    "$ordered_from": {
+      "oneOf": [
+        { "$ref": "ComplexTypes/ordered_from.json" },
+        { "type": "null" }
+      ]
     }
   }
 }

--- a/Sift/Schema/custom_event.json
+++ b/Sift/Schema/custom_event.json
@@ -11,6 +11,15 @@
     },
     "$session_id": {
       "type": [ "string", "null" ]
+    },
+    "$brand_name": {
+      "type": [ "string", "null" ]
+    },
+    "$site_country": {
+      "type": [ "string", "null" ]
+    },
+    "$site_domain": {
+      "type": [ "string", "null" ]
     }
   }
 }

--- a/Sift/Schema/login.json
+++ b/Sift/Schema/login.json
@@ -28,6 +28,15 @@
         { "$ref": "ComplexTypes/browser.json" },
         { "type": "null" }
       ]
+    },
+    "$brand_name": {
+      "type": [ "string", "null" ]
+    },
+    "$site_country": {
+      "type": [ "string", "null" ]
+    },
+    "$site_domain": {
+      "type": [ "string", "null" ]
     }
   }
 }

--- a/Sift/Schema/logout.json
+++ b/Sift/Schema/logout.json
@@ -22,6 +22,15 @@
         { "$ref": "ComplexTypes/browser.json" },
         { "type": "null" }
       ]
+    },
+    "$brand_name": {
+      "type": [ "string", "null" ]
+    },
+    "$site_country": {
+      "type": [ "string", "null" ]
+    },
+    "$site_domain": {
+      "type": [ "string", "null" ]
     }
   }
 }

--- a/Sift/Schema/order_status.json
+++ b/Sift/Schema/order_status.json
@@ -46,6 +46,15 @@
         { "$ref": "ComplexTypes/browser.json" },
         { "type": "null" }
       ]
+    },
+    "$brand_name": {
+      "type": [ "string", "null" ]
+    },
+    "$site_country": {
+      "type": [ "string", "null" ]
+    },
+    "$site_domain": {
+      "type": [ "string", "null" ]
     }
   }
 }

--- a/Sift/Schema/remove_item_from_cart.json
+++ b/Sift/Schema/remove_item_from_cart.json
@@ -31,6 +31,15 @@
         { "$ref": "ComplexTypes/browser.json" },
         { "type": "null" }
       ]
+    },
+    "$brand_name": {
+      "type": [ "string", "null" ]
+    },
+    "$site_country": {
+      "type": [ "string", "null" ]
+    },
+    "$site_domain": {
+      "type": [ "string", "null" ]
     }
   }
 }

--- a/Sift/Schema/security_notification.json
+++ b/Sift/Schema/security_notification.json
@@ -34,6 +34,15 @@
         { "$ref": "ComplexTypes/browser.json" },
         { "type": "null" }
       ]
+    },
+    "$brand_name": {
+      "type": [ "string", "null" ]
+    },
+    "$site_country": {
+      "type": [ "string", "null" ]
+    },
+    "$site_domain": {
+      "type": [ "string", "null" ]
     }
   }
 }

--- a/Sift/Schema/transaction.json
+++ b/Sift/Schema/transaction.json
@@ -71,6 +71,21 @@
         { "$ref": "ComplexTypes/browser.json" },
         { "type": "null" }
       ]
+    },
+    "$brand_name": {
+      "type": [ "string", "null" ]
+    },
+    "$site_country": {
+      "type": [ "string", "null" ]
+    },
+    "$site_domain": {
+      "type": [ "string", "null" ]
+    },
+    "$ordered_from": {
+      "oneOf": [
+        { "$ref": "ComplexTypes/ordered_from.json" },
+        { "type": "null" }
+      ]
     }
   }
 }

--- a/Sift/Schema/update_account.json
+++ b/Sift/Schema/update_account.json
@@ -59,6 +59,15 @@
         { "$ref": "ComplexTypes/browser.json" },
         { "type": "null" }
       ]
+    },
+    "$brand_name": {
+      "type": [ "string", "null" ]
+    },
+    "$site_country": {
+      "type": [ "string", "null" ]
+    },
+    "$site_domain": {
+      "type": [ "string", "null" ]
     }
   }
 }

--- a/Sift/Schema/update_order.json
+++ b/Sift/Schema/update_order.json
@@ -71,8 +71,23 @@
       ]
     },
     "$browser": {
+        "oneOf": [
+          { "$ref": "ComplexTypes/browser.json" },
+          { "type": "null" }
+        ]
+    },
+    "$brand_name": {
+      "type": [ "string", "null" ]
+    },
+    "$site_country": {
+      "type": [ "string", "null" ]
+    },
+    "$site_domain": {
+      "type": [ "string", "null" ]
+    },
+    "$ordered_from": {
       "oneOf": [
-        { "$ref": "ComplexTypes/browser.json" },
+        { "$ref": "ComplexTypes/ordered_from.json" },
         { "type": "null" }
       ]
     }

--- a/Sift/Sift.csproj
+++ b/Sift/Sift.csproj
@@ -4,7 +4,7 @@
     <Authors>Sift, Gary Lee</Authors>
     <AssemblyTitle>Sift</AssemblyTitle>
     <AssemblyName>Sift</AssemblyName>
-    <VersionPrefix>0.3.0</VersionPrefix>
+    <VersionPrefix>0.4.0</VersionPrefix>
     <VersionSuffix>beta</VersionSuffix>
     <PackageReleaseNotes>Beta release</PackageReleaseNotes>
     <TargetFramework>netstandard2.0</TargetFramework>

--- a/Test/Test.cs
+++ b/Test/Test.cs
@@ -154,30 +154,26 @@ namespace Test
 
             // Augment with custom fields
             createOrder.AddField("foo", "bar");
+            Console.WriteLine(createOrder.ToJson());
             Assert.Equal("{\"$type\":\"$create_order\",\"$user_id\":\"test_dotnet_booking_with_all_fields\"," +
-                         "\"$session_id\":\"gigtleqddo84l8cm15qe4il\"," +
-                         "\"$ordered_from\" : {\"$store_id\": \"12345\",\"$store_address\": {\"$address_1\": \"2100 Main Street\"," +
-                         "\"$address_2\": \"Apt 3B\",\"$city\": \"New London\",\"$country\": \"US\",\"$name\": \"Bill Jones\"," +
-                         "\"$phone\": \"1-415-555-6041\",\"$region\": \"New Hampshire\",\"$zipcode\": \"03257\"},"+
-                         "\"$order_id\":\"oid\",\"$user_email\":\"bill@gmail.com\",\"$amount\":1000000000000," +
-                         "\"$currency_code\":\"USD\",\"$billing_address\":{\"$name\":\"gary\"," +
-                         "\"$site_country\":\"US\",\"$site_domain\":\"sift.com\",\"$brand_name\":\"sift\"," +
-                         "\"$city\":\"san francisco\"},\"$bookings\":[{\"$booking_type\":\"$flight\"," +
-                         "\"$title\":\"SFO - LAS, 2 Adults\",\"$start_time\":2038412903,\"$end_time\":2038412903," +
-                         "\"$price\":49900000,\"$currency_code\":\"USD\",\"$quantity\":1,\"$guests\":[{\"$name\":\"John Doe\"," +
-                         "\"$email\":\"jdoe@domain.com\",\"$phone\":\"1-415-555-6040\",\"$loyalty_program\":\"skymiles\"," +
-                         "\"$loyalty_program_id\":\"PSOV34DF\",\"$birth_date\":\"1985-01-19\"},{\"$name\":\"John Doe\"}]," +
-                         "\"$segments\":[{\"$start_time\":203841290300,\"$end_time\":2038412903,\"$vessel_number\":\"LH454\"," +
-                         "\"$departure_airport_code\":\"SFO\",\"$arrival_airport_code\":\"LAS\",\"$fare_class\":\"Premium Economy\"," +
-                         "\"$departure_address\":{\"$name\":\"Bill Jones\",\"$address_1\":\"2100 Main Street\",\"$address_2\":\"Apt 3B\"," +
-                         "\"$city\":\"New London\",\"$region\":\"New Hampshire\",\"$country\":\"US\",\"$zipcode\":\"03257\"," +
-                         "\"$phone\":\"1-415-555-6040\"},\"$arrival_address\":{\"$name\":\"Bill Jones\",\"$address_1\":\"2100 Main Street\"," +
-                         "\"$address_2\":\"Apt 3B\",\"$city\":\"New London\",\"$region\":\"New Hampshire\",\"$country\":\"US\"," +
-                         "\"$zipcode\":\"03257\",\"$phone\":\"1-415-555-6040\"}}],\"$room_type\":\"deluxe\",\"$event_id\":\"event-123\"," +
-                         "\"$venue_id\":\"venue-123\",\"$location\":{\"$name\":\"Bill Jones\",\"$address_1\":\"2100 Main Street\"," +
-                         "\"$address_2\":\"Apt 3B\",\"$city\":\"New London\",\"$region\":\"New Hampshire\",\"$country\":\"US\"," +
-                         "\"$zipcode\":\"03257\",\"$phone\":\"1-415-555-6040\"},\"$category\":\"pop\",\"$tags\":[\"tag-123\",\"tag-321\"]}]," +
-                         "\"$app\":{\"$app_name\":\"my app\",\"$app_version\":\"1.0\",\"$client_language\":\"en-US\"},\"foo\":\"bar\"}",
+                         "\"$session_id\":\"gigtleqddo84l8cm15qe4il\",\"$order_id\":\"oid\",\"$user_email\":\"bill@gmail.com\"," +
+                         "\"$amount\":1000000000000,\"$currency_code\":\"USD\",\"$billing_address\":{\"$name\":\"gary\",\"$city\":\"san francisco\"}," +
+                         "\"$bookings\":[{\"$booking_type\":\"$flight\",\"$title\":\"SFO - LAS, 2 Adults\",\"$start_time\":2038412903," +
+                         "\"$end_time\":2038412903,\"$price\":49900000,\"$currency_code\":\"USD\",\"$quantity\":1,\"$guests\":[{\"$name\":\"John Doe\"," +
+                         "\"$email\":\"jdoe@domain.com\",\"$phone\":\"1-415-555-6040\",\"$loyalty_program\":\"skymiles\",\"$loyalty_program_id\":\"PSOV34DF\"," +
+                         "\"$birth_date\":\"1985-01-19\"},{\"$name\":\"John Doe\"}],\"$segments\":[{\"$start_time\":203841290300,\"$end_time\":2038412903," +
+                         "\"$vessel_number\":\"LH454\",\"$departure_airport_code\":\"SFO\",\"$arrival_airport_code\":\"LAS\",\"$fare_class\":\"Premium Economy\"," +
+                         "\"$departure_address\":{\"$name\":\"Bill Jones\",\"$address_1\":\"2100 Main Street\",\"$address_2\":\"Apt 3B\",\"$city\":\"New London\"," +
+                         "\"$region\":\"New Hampshire\",\"$country\":\"US\",\"$zipcode\":\"03257\",\"$phone\":\"1-415-555-6040\"}," +
+                         "\"$arrival_address\":{\"$name\":\"Bill Jones\",\"$address_1\":\"2100 Main Street\",\"$address_2\":\"Apt 3B\",\"$city\":\"New London\"," +
+                         "\"$region\":\"New Hampshire\",\"$country\":\"US\",\"$zipcode\":\"03257\",\"$phone\":\"1-415-555-6040\"}}],\"$room_type\":\"deluxe\"," +
+                         "\"$event_id\":\"event-123\",\"$venue_id\":\"venue-123\",\"$location\":{\"$name\":\"Bill Jones\",\"$address_1\":\"2100 Main Street\"," +
+                         "\"$address_2\":\"Apt 3B\",\"$city\":\"New London\",\"$region\":\"New Hampshire\",\"$country\":\"US\",\"$zipcode\":\"03257\"," +
+                         "\"$phone\":\"1-415-555-6040\"},\"$category\":\"pop\",\"$tags\":[\"tag-123\",\"tag-321\"]}],\"$app\":{\"$app_name\":\"my app\"," +
+                         "\"$app_version\":\"1.0\",\"$client_language\":\"en-US\"},\"$brand_name\":\"sift\",\"$site_country\":\"US\",\"$site_domain\":\"sift.com\"," +
+                         "\"$ordered_from\":{\"$store_id\":\"123\",\"$store_address\":{\"$name\":\"Bill Jones\",\"$address_1\":\"2100 Main Street\"," +
+                         "\"$address_2\":\"Apt 3B\",\"$city\":\"New London\",\"$region\":\"New Hampshire\",\"$country\":\"US\",\"$zipcode\":\"03257\"," +
+                         "\"$phone\":\"1-415-555-6040\"}},\"foo\":\"bar\"}",
                          createOrder.ToJson());
 
 

--- a/Test/Test.cs
+++ b/Test/Test.cs
@@ -129,16 +129,39 @@ namespace Test
                 app = new App
                 {
                     app_name = "my app",
-                    app_version = "1.0"
-                }
+                    app_version = "1.0",
+                    client_language = "en-US"
+                },
+                ordered_from = new OrderedFrom
+                {
+                    store_id = "123",
+                    store_address = new Address
+                    {
+                        name = "Bill Jones",
+                        phone = "1-415-555-6040",
+                        address_1 = "2100 Main Street",
+                        address_2 = "Apt 3B",
+                        city = "New London",
+                        region = "New Hampshire",
+                        country = "US",
+                        zipcode = "03257"
+                    }
+                },
+                site_country = "US",
+                site_domain = "sift.com",
+                brand_name = "sift"
             };
 
             // Augment with custom fields
             createOrder.AddField("foo", "bar");
             Assert.Equal("{\"$type\":\"$create_order\",\"$user_id\":\"test_dotnet_booking_with_all_fields\"," +
                          "\"$session_id\":\"gigtleqddo84l8cm15qe4il\"," +
+                         "\"$ordered_from\" : {\"$store_id\": \"12345\",\"$store_address\": {\"$address_1\": \"2100 Main Street\"," +
+                         "\"$address_2\": \"Apt 3B\",\"$city\": \"New London\",\"$country\": \"US\",\"$name\": \"Bill Jones\"," +
+                         "\"$phone\": \"1-415-555-6041\",\"$region\": \"New Hampshire\",\"$zipcode\": \"03257\"},"+
                          "\"$order_id\":\"oid\",\"$user_email\":\"bill@gmail.com\",\"$amount\":1000000000000," +
                          "\"$currency_code\":\"USD\",\"$billing_address\":{\"$name\":\"gary\"," +
+                         "\"$site_country\":\"US\",\"$site_domain\":\"sift.com\",\"$brand_name\":\"sift\"," +
                          "\"$city\":\"san francisco\"},\"$bookings\":[{\"$booking_type\":\"$flight\"," +
                          "\"$title\":\"SFO - LAS, 2 Adults\",\"$start_time\":2038412903,\"$end_time\":2038412903," +
                          "\"$price\":49900000,\"$currency_code\":\"USD\",\"$quantity\":1,\"$guests\":[{\"$name\":\"John Doe\"," +
@@ -154,7 +177,7 @@ namespace Test
                          "\"$venue_id\":\"venue-123\",\"$location\":{\"$name\":\"Bill Jones\",\"$address_1\":\"2100 Main Street\"," +
                          "\"$address_2\":\"Apt 3B\",\"$city\":\"New London\",\"$region\":\"New Hampshire\",\"$country\":\"US\"," +
                          "\"$zipcode\":\"03257\",\"$phone\":\"1-415-555-6040\"},\"$category\":\"pop\",\"$tags\":[\"tag-123\",\"tag-321\"]}]," +
-                         "\"$app\":{\"$app_name\":\"my app\",\"$app_version\":\"1.0\"},\"foo\":\"bar\"}",
+                         "\"$app\":{\"$app_name\":\"my app\",\"$app_version\":\"1.0\",\"$client_language\":\"en-US\"},\"foo\":\"bar\"}",
                          createOrder.ToJson());
 
 

--- a/Test/Test.cs
+++ b/Test/Test.cs
@@ -239,7 +239,7 @@ namespace Test
             createOrder.AddField("foo", "bar");
             Assert.Equal("{\"$type\":\"$create_order\",\"$user_id\":\"test_dotnet_booking_with_all_fields\",\"$session_id\":\"gigtleqddo84l8cm15qe4il\"," +
                          "\"$order_id\":\"oid\",\"$user_email\":\"bill@gmail.com\",\"$amount\":1000000000000,\"$currency_code\":\"USD\"," +
-                         "\"$browser\":{\"$user_agent\":\"Mozilla 5.0 (Macintosh; Intel Mac OS X 10_12_3) AppleWebKit 537.36 (KHTML, like Gecko) Chrome 56.0.2924.87 Safari 537.36\"," +
+                         "\"$browser\":{\"$user_agent\":\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36\"," +
                          "\"$accept_language\":\"en-US\",\"$content_language\":\"en-GB\"},\"foo\":\"bar\"}",
                          createOrder.ToJson());
 

--- a/Test/Test.cs
+++ b/Test/Test.cs
@@ -154,7 +154,6 @@ namespace Test
 
             // Augment with custom fields
             createOrder.AddField("foo", "bar");
-            Console.WriteLine(createOrder.ToJson());
             Assert.Equal("{\"$type\":\"$create_order\",\"$user_id\":\"test_dotnet_booking_with_all_fields\"," +
                          "\"$session_id\":\"gigtleqddo84l8cm15qe4il\",\"$order_id\":\"oid\",\"$user_email\":\"bill@gmail.com\"," +
                          "\"$amount\":1000000000000,\"$currency_code\":\"USD\",\"$billing_address\":{\"$name\":\"gary\",\"$city\":\"san francisco\"}," +
@@ -215,6 +214,52 @@ namespace Test
             Assert.Equal("{\"$type\":\"make_call\",\"$user_id\":\"gary\",\"foo\":" +
                               "\"bar\",\"payment_status\":\"$success\"}",
                               makeCall.ToJson());
+        }
+
+        [Fact]
+        public void TestEventWithBrowser()
+        {
+            var createOrder = new CreateOrder
+            {
+                user_id = "test_dotnet_booking_with_all_fields",
+                order_id = "oid",
+                amount = 1000000000000L,
+                currency_code = "USD",
+                session_id = "gigtleqddo84l8cm15qe4il",
+                user_email = "bill@gmail.com",
+                browser = new Browser
+                {
+                    user_agent       = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36",
+                    accept_language  = "en-US",
+                    content_language = "en-GB"
+                }
+            };
+
+            // Augment with custom fields
+            createOrder.AddField("foo", "bar");
+            Assert.Equal("{\"$type\":\"$create_order\",\"$user_id\":\"test_dotnet_booking_with_all_fields\",\"$session_id\":\"gigtleqddo84l8cm15qe4il\"," +
+                         "\"$order_id\":\"oid\",\"$user_email\":\"bill@gmail.com\",\"$amount\":1000000000000,\"$currency_code\":\"USD\"," +
+                         "\"$browser\":{\"$user_agent\":\"Mozilla 5.0 (Macintosh; Intel Mac OS X 10_12_3) AppleWebKit 537.36 (KHTML, like Gecko) Chrome 56.0.2924.87 Safari 537.36\"," +
+                         "\"$accept_language\":\"en-US\",\"$content_language\":\"en-GB\"},\"foo\":\"bar\"}",
+                         createOrder.ToJson());
+
+
+            EventRequest eventRequest = new EventRequest
+            {
+                Event = createOrder
+            };
+
+            Assert.Equal("https://api.sift.com/v205/events", eventRequest.Request.RequestUri.ToString());
+
+            eventRequest = new EventRequest
+            {
+                Event = createOrder,
+                AbuseTypes = { "legacy", "payment_abuse" },
+                ReturnScore = true
+            };
+
+            Assert.Equal("https://api.sift.com/v205/events?abuse_types=legacy,payment_abuse&return_score=true",
+                         Uri.UnescapeDataString(eventRequest.Request.RequestUri.ToString()));
         }
     }
 }


### PR DESCRIPTION
**Purpose**
Add additional fields to support user-level and order/transaction-level segmentation of the data which can be used for various purposes in the future like reporting, workflow management, permissions, etc.

**Technical Overview**
- Add support for `$client_language` field to `$app` complex field
- Add support for `$accept_language` and `content_language` fields to `$browser` complex field
- Add support for `$brand_name`, `$site_country` and `$site_domain` fields to custom events and all reserved events except `$chargeback`, `$link_session_to_user` and `$flag_content`
- Add support for `$ordered_from` complex field to `$create_order`, `$update_order`, and `$transaction` events

**Testing Plan**
- Updated unit tests
- Send sample events using SiftClient to the internal experiment environment and verify the changes using the internal experiment console.

**Deployment**
- Publish the package using NuGet