### PR TITLE
(For John) Add $decline_category to $transaction

### DIFF
--- a/Sift/Schema/transaction.json
+++ b/Sift/Schema/transaction.json
@@ -86,6 +86,9 @@
         { "$ref": "ComplexTypes/ordered_from.json" },
         { "type": "null" }
       ]
+    },
+    "$decline_category": {
+      "type": [ "string", "null" ]
     }
   }
 }

--- a/Sift/Sift.csproj
+++ b/Sift/Sift.csproj
@@ -4,7 +4,7 @@
     <Authors>Sift, Gary Lee</Authors>
     <AssemblyTitle>Sift</AssemblyTitle>
     <AssemblyName>Sift</AssemblyName>
-    <VersionPrefix>0.4.0</VersionPrefix>
+    <VersionPrefix>0.5.0</VersionPrefix>
     <VersionSuffix>beta</VersionSuffix>
     <PackageReleaseNotes>Beta release</PackageReleaseNotes>
     <TargetFramework>netstandard2.0</TargetFramework>

--- a/Test/Test.cs
+++ b/Test/Test.cs
@@ -261,5 +261,43 @@ namespace Test
             Assert.Equal("https://api.sift.com/v205/events?abuse_types=legacy,payment_abuse&return_score=true",
                          Uri.UnescapeDataString(eventRequest.Request.RequestUri.ToString()));
         }
+
+        [Fact]
+        public void TestTransactionEvent()
+        {
+            var transaction = new Transaction
+            {
+                user_id = "test_dotnet_booking_with_all_fields",
+                amount = 1000000000000L,
+                currency_code = "USD",
+                session_id = "gigtleqddo84l8cm15qe4il",
+                transaction_type = "$sale",
+                transaction_status = "$failure",
+                decline_category = "$invalid"
+            };
+
+            // Augment with custom fields
+            transaction.AddField("foo", "bar");
+            Assert.Equal("{\"$type\":\"$transaction\",\"$user_id\":\"test_dotnet_booking_with_all_fields\",\"$session_id\":\"gigtleqddo84l8cm15qe4il\"," +
+                                 "\"$transaction_type\":\"$sale\",\"$transaction_status\":\"$failure\",\"$amount\":1000000000000,\"$currency_code\":\"USD\"," +
+                                 "\"$decline_category\":\"$invalid\",\"foo\":\"bar\"}", transaction.ToJson());
+
+            EventRequest eventRequest = new EventRequest
+            {
+                Event = transaction
+            };
+
+            Assert.Equal("https://api.sift.com/v205/events", eventRequest.Request.RequestUri.ToString());
+
+            eventRequest = new EventRequest
+            {
+                Event = transaction,
+                AbuseTypes = { "legacy", "payment_abuse" },
+                ReturnScore = true
+            };
+
+            Assert.Equal("https://api.sift.com/v205/events?abuse_types=legacy,payment_abuse&return_score=true",
+                          Uri.UnescapeDataString(eventRequest.Request.RequestUri.ToString()));
+        }
     }
 }


### PR DESCRIPTION
**Purpose**

- Add additional $decline_category field to $transaction event to make it possible to pass decline reason on transaction level.

**Technical Overview**

- Adding $decline_category field to Transaction schema

**Testing Plan**

- Run unit tests
- Send sample events using SiftClient to the internal experiment environment and verify the changes using the internal experiment console.

 **Deployment**

- Publish the package using NuGet