### PR TITLE
Fix Client constructor when passing the HttpClient

### DIFF
--- a/Sift/Core/Client.cs
+++ b/Sift/Core/Client.cs
@@ -20,6 +20,7 @@ namespace Sift
         }
 
         public Client(String apiKey, HttpClient http) {
+            this.apiKey = apiKey;
             this.http = http;
         }
 


### PR DESCRIPTION
This aims to fix a bug where in the constructor that has 2 parameters (ApiKey and HttpClient), the ApiKey parameter passed to the constructor is not saved to the private field.