### PR TITLE
adding support for sepa complex field in payment_method

### DIFF
--- a/Sift/Schema/ComplexTypes/payment_method.json
+++ b/Sift/Schema/ComplexTypes/payment_method.json
@@ -71,6 +71,12 @@
         { "$ref": "ach.json" },
         { "type": "null" }
       ]
+    },
+    "$sepa": {
+        "oneOf": [
+            { "$ref": "sepa.json" },
+            { "type": "null" }
+        ]
     }
   }
 }

--- a/Sift/Schema/ComplexTypes/sepa.json
+++ b/Sift/Schema/ComplexTypes/sepa.json
@@ -1,0 +1,23 @@
+﻿{
+    "$schema": "http://json-schema.org/draft-04/schema",
+    "title": "Sepa",
+    "type": "object",
+    "required": [ "$sepa_type", "$account_holder_name", "$shortened_iban" ],
+    "properties": {
+        "$sepa_type": {
+            "type": [ "string", "null" ]
+        },
+        "$account_holder_name": {
+            "type": [ "string", "null" ]
+        },
+        "$shortened_iban": {
+            "type": [ "string", "null" ]
+        },
+        "$bic": {
+            "type": [ "string", "null" ]
+        },
+        "$mandate_id": {
+            "type": [ "string", "null" ]
+        }
+    }
+}


### PR DESCRIPTION
**Purpose**
- Add `$sepa` complex field to support SEPA payment method which can be used for various fintech purposes in the future like feature extraction, reporting, workflow management, etc.

**Technical Overview**
- Add support  for `$sepa` complex field which contains `$sepa_type`, `$account_holder_name`, `$shortened_iban`, `$bic`, and `$mandate_id` fields which would be part of `$payment_method` field.

**Testing Plan**
- [x] Updated unit tests

**Deployment**
(Once all the fintech-related changes are merged)
- Publish the package using NuGet

Note - I will update the changelog during the last PR as it would cause conflicts now.