### PR TITLE
Wire payments fintech dotnet changes

### DIFF
--- a/Sift/Schema/ComplexTypes/payment_method.json
+++ b/Sift/Schema/ComplexTypes/payment_method.json
@@ -77,6 +77,12 @@
             { "$ref": "sepa.json" },
             { "type": "null" }
         ]
+    },
+    "$wire": {
+      "oneOf": [
+        { "$ref": "wire.json" },
+        { "type": "null" }
+      ]
     }
   }
 }

--- a/Sift/Schema/ComplexTypes/wire.json
+++ b/Sift/Schema/ComplexTypes/wire.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema",
+  "title": "Wire",
+  "type": "object",
+  "required": [ "$wire_type", "$account_holder_name"],
+  "properties": {
+    "$wire_type": {
+      "type": [ "string", "null" ]
+    },
+    "$account_holder_name": {
+      "type": [ "string", "null" ]
+    },
+    "$account_number": {
+      "type": [ "string", "null" ]
+    },
+    "$bank_name": {
+      "type": [ "string", "null" ]
+    },
+    "$bank_country": {
+      "type": [ "string", "null" ]
+    },
+    "$routing_number": {
+      "type": [ "string", "null" ]
+    },
+    "$swift_id": {
+      "type": [ "string", "null" ]
+    },
+    "$bic": {
+      "type": [ "string", "null" ]
+    }
+  }
+}

--- a/Test/Test.cs
+++ b/Test/Test.cs
@@ -394,5 +394,56 @@ namespace Test
             Assert.Equal("https://api.sift.com/v206/events?abuse_types=legacy,payment_abuse&return_score=true",
                           Uri.UnescapeDataString(eventRequest.Request.RequestUri.ToString()));
         }
+
+        [Fact]
+        public void TestCreateOrderEvent206WithWirePaymentMethod()
+        {
+            var createOrder = new CreateOrder
+            {
+                user_id = "test_dotnet_fintech_payment_methods",
+                session_id = "gigtleqddo84l8cm15qe4il",
+                order_id = "12345",
+                payment_methods = new ObservableCollection<PaymentMethod>()
+                {
+                    new PaymentMethod
+                    {
+                        wire = new Wire
+                        {
+                            wire_type = "$credit",
+                            account_holder_name = "John Doe",
+                            account_number = "12345",
+                            bank_name = "Chase",
+                            bank_country = "US",
+                            swift_id = "CHASUS33XX"
+                        }
+                    }
+                }
+            };
+
+            // Augment with custom fields
+            createOrder.AddField("foo", "bar");
+            Assert.Equal("{\"$type\":\"$create_order\",\"$user_id\":\"test_dotnet_fintech_payment_methods\",\"$session_id\":\"gigtleqddo84l8cm15qe4il\"," +
+                                 "\"$order_id\":\"12345\",\"$payment_methods\":[{\"$wire\":{\"$wire_type\":\"$credit\",\"$account_holder_name\":\"John Doe\"," +
+                                 "\"$account_number\":\"12345\",\"$bank_name\":\"Chase\",\"$bank_country\":\"US\",\"$swift_id\":\"CHASUS33XX\"}}],\"foo\":\"bar\"}",
+                                 createOrder.ToJson());
+
+            EventRequest eventRequest = new EventRequest
+            {
+                Event = createOrder
+            };
+
+            Assert.Equal("https://api.sift.com/v206/events", eventRequest.Request.RequestUri.ToString());
+
+            eventRequest = new EventRequest
+            {
+                Event = createOrder,
+                AbuseTypes = { "legacy", "payment_abuse" },
+                ReturnScore = true
+            };
+
+            Assert.Equal("https://api.sift.com/v206/events?abuse_types=legacy,payment_abuse&return_score=true",
+                          Uri.UnescapeDataString(eventRequest.Request.RequestUri.ToString()));
+        }
+
     }
 }


### PR DESCRIPTION
Add new version 3.5.0 corresponding to new API version 206. This PR has Wire complex payment method added

Testing:
./build.sh executed tasks clean, restore, generate, build, test successfully