### PR TITLE
adding support for 3ds, sepa, merchant_profile, sent_address and received_address fields for fintech

### DIFF
--- a/Sift/Schema/ComplexTypes/merchant_profile.json
+++ b/Sift/Schema/ComplexTypes/merchant_profile.json
@@ -1,0 +1,22 @@
+﻿{
+    "$schema": "http://json-schema.org/draft-04/schema",
+    "title": "OrderedFrom",
+    "type": "object",
+    "properties": {
+        "$merchant_id": {
+            "type": [ "string", "null" ]
+        },
+        "$merchant_category_code": {
+            "type": [ "string", "null" ]
+        },
+        "$merchant_name": {
+            "type": [ "string", "null" ]
+        },
+        "$merchant_address": {
+            "oneOf": [
+                { "$ref": "address.json" },
+                { "type": "null" }
+            ]
+        }
+    }
+}

--- a/Sift/Schema/ComplexTypes/payment_method.json
+++ b/Sift/Schema/ComplexTypes/payment_method.json
@@ -65,6 +65,15 @@
     },
     "$stripe_brand": {
       "type": [ "string", "null" ]
+    },
+    "$shortened_iban_first6": {
+        "type": [ "string", "null" ]
+    },
+    "$shortened_iban_last4": {
+        "type": [ "string", "null" ]
+    },
+    "$sepa_direct_debit_mandate": {
+        "type": [ "boolean", "null" ]
     }
   }
 }

--- a/Sift/Schema/create_order.json
+++ b/Sift/Schema/create_order.json
@@ -90,6 +90,12 @@
         { "$ref": "ComplexTypes/ordered_from.json" },
         { "type": "null" }
       ]
+    },
+    "$merchant_profile": {
+        "oneOf": [
+            { "$ref": "ComplexTypes/merchant_profile.json" },
+            { "type": "null" }
+        ]
     }
   }
 }

--- a/Sift/Schema/transaction.json
+++ b/Sift/Schema/transaction.json
@@ -89,6 +89,33 @@
     },
     "$decline_category": {
       "type": [ "string", "null" ]
+    },
+    "$sent_address": {
+        "oneOf": [
+            { "$ref": "ComplexTypes/address.json" },
+            { "type": "null" }
+        ]
+    },
+    "$received_address": {
+        "oneOf": [
+            { "$ref": "ComplexTypes/address.json" },
+            { "type": "null" }
+        ]
+    },
+    "$status_3ds": {
+        "type": [ "string", "null" ]
+    },
+    "$triggered_3ds": {
+        "type": [ "string", "null" ]
+    },
+    "$merchant_initiated_transaction": {
+        "type": [ "boolean", "null" ]
+    },
+    "$merchant_profile": {
+        "oneOf": [
+            { "$ref": "ComplexTypes/merchant_profile.json" },
+            { "type": "null" }
+        ]
     }
   }
 }

--- a/Sift/Sift.csproj
+++ b/Sift/Sift.csproj
@@ -4,7 +4,7 @@
     <Authors>Sift, Gary Lee</Authors>
     <AssemblyTitle>Sift</AssemblyTitle>
     <AssemblyName>Sift</AssemblyName>
-    <VersionPrefix>0.6.0</VersionPrefix>
+    <VersionPrefix>0.7.0</VersionPrefix>
     <VersionSuffix>beta</VersionSuffix>
     <PackageReleaseNotes>Beta release</PackageReleaseNotes>
     <TargetFramework>netstandard2.0</TargetFramework>


### PR DESCRIPTION
**Purpose**
- Add support for new Fintech API fields which can be used for various purposes in the future like feature extraction, reporting, workflow management, etc.

**Technical Overview**
- Support for the following API fields is added
  - ` $merchant_profile` complex field. This field contains the fields `$merchant_id`, `$merchant_name`, `$merchant_address`, and `$merchant_category_code`. Thiis field is supported in `$create_order`, `$update_order`, and `$transaction` events.
  - `$status_3ds`, `$triggered_3ds`, `$merchant_initiated_transaction`, `$sent_address`, and `$received_address` are supported in `$transaction` event.
  - `$shortened_iban_first6`, `$shortened_iban_last4`, and `$sepa_direct_debit_mandate` are supported in `$transaction` event and `$payment_method` field

**Testing Plan**
- [x] Updated unit tests

**Deployment**
(Once all the fintech-related changes are merged)
- Publish the package using NuGet
