### PR TITLE
Adding support for $merchant_profile complex field to $create_account , $update_account, and $chargeback events

### DIFF
--- a/Sift/Schema/chargeback.json
+++ b/Sift/Schema/chargeback.json
@@ -37,6 +37,12 @@
         { "$ref": "ComplexTypes/browser.json" },
         { "type": "null" }
       ]
+    },
+    "$merchant_profile": {
+        "oneOf": [
+            { "$ref": "ComplexTypes/merchant_profile.json" },
+            { "type": "null" }
+        ]
     }
   }
 }

--- a/Sift/Schema/create_account.json
+++ b/Sift/Schema/create_account.json
@@ -69,6 +69,12 @@
     },
     "$site_domain": {
       "type": [ "string", "null" ]
+    },
+    "$merchant_profile": {
+        "oneOf": [
+            { "$ref": "ComplexTypes/merchant_profile.json" },
+            { "type": "null" }
+        ]
     }
   }
 }

--- a/Sift/Schema/create_account.json
+++ b/Sift/Schema/create_account.json
@@ -75,6 +75,10 @@
             { "$ref": "ComplexTypes/merchant_profile.json" },
             { "type": "null" }
         ]
+    },
+    "$account_types": {
+        "type": [ "array", "null" ],
+        "items": { "type": "string" }
     }
   }
 }

--- a/Sift/Schema/login.json
+++ b/Sift/Schema/login.json
@@ -11,7 +11,22 @@
     "$user_id": {
       "type": [ "string", "null" ]
     },
+    "$session_id": {
+      "type": [ "string", "null" ]
+    },
+    "$user_email": {
+      "type": [ "string", "null" ]
+    },
     "$login_status": {
+      "type": [ "string", "null" ]
+    },
+    "$failure_reason": {
+      "type": [ "string", "null" ]
+    },
+    "$social_sign_on_type": {
+      "type": [ "string", "null" ]
+    },
+    "$username": {
       "type": [ "string", "null" ]
     },
     "$ip": {
@@ -37,6 +52,10 @@
     },
     "$site_domain": {
       "type": [ "string", "null" ]
+    },
+    "$account_types": {
+        "type": [ "array", "null" ],
+        "items": { "type": "string" }
     }
   }
 }

--- a/Sift/Schema/update_account.json
+++ b/Sift/Schema/update_account.json
@@ -74,6 +74,10 @@
             { "$ref": "ComplexTypes/merchant_profile.json" },
             { "type": "null" }
         ]
+    },
+    "$account_types": {
+        "type": [ "array", "null" ],
+        "items": { "type": "string" }
     }
   }
 }

--- a/Sift/Schema/update_account.json
+++ b/Sift/Schema/update_account.json
@@ -68,6 +68,12 @@
     },
     "$site_domain": {
       "type": [ "string", "null" ]
+    },
+    "$merchant_profile": {
+        "oneOf": [
+            { "$ref": "ComplexTypes/merchant_profile.json" },
+            { "type": "null" }
+        ]
     }
   }
 }

--- a/Sift/Sift.csproj
+++ b/Sift/Sift.csproj
@@ -4,7 +4,7 @@
     <Authors>Sift, Gary Lee</Authors>
     <AssemblyTitle>Sift</AssemblyTitle>
     <AssemblyName>Sift</AssemblyName>
-    <VersionPrefix>0.7.0</VersionPrefix>
+    <VersionPrefix>0.8.0</VersionPrefix>
     <VersionSuffix>beta</VersionSuffix>
     <PackageReleaseNotes>Beta release</PackageReleaseNotes>
     <TargetFramework>netstandard2.0</TargetFramework>

--- a/Test/Test.cs
+++ b/Test/Test.cs
@@ -636,17 +636,19 @@ namespace Test
                         country = "US",
                         zipcode = "03257"
                     }
-                }
+                },
+                account_types = new ObservableCollection<string>() { "merchant", "premium" }
             };
 
             // Augment with custom fields
             createAccount.AddField("foo", "bar");
 
             Assert.Equal("{\"$type\":\"$create_account\",\"$user_id\":\"test_dotnet_create_account_event\",\"$session_id\":\"gigtleqddo84l8cm15qe4il\"," +
-                                 "\"$user_email\":\"bill@gmail.com\",\"$name\":\"Bill Jones\",\"$referrer_user_id\":\"janejane101\",\"$social_sign_on_type\":\"$twitter\"," +
-                                 "\"$merchant_profile\":{\"$merchant_id\":\"123\",\"$merchant_category_code\":\"9876\",\"$merchant_name\":\"ABC Merchant\",\"$merchant_address\":" +
-                                 "{\"$name\":\"Bill Jones\",\"$address_1\":\"2100 Main Street\",\"$address_2\":\"Apt 3B\",\"$city\":\"New London\",\"$region\":\"New Hampshire\"," +
-                                 "\"$country\":\"US\",\"$zipcode\":\"03257\",\"$phone\":\"1-415-555-6040\"}},\"foo\":\"bar\"}",
+                                 "\"$user_email\":\"bill@gmail.com\",\"$name\":\"Bill Jones\",\"$referrer_user_id\":\"janejane101\",\"$social_sign_on_type\":" +
+                                 "\"$twitter\",\"$merchant_profile\":{\"$merchant_id\":\"123\",\"$merchant_category_code\":\"9876\",\"$merchant_name\":\"ABC Merchant\"," +
+                                 "\"$merchant_address\":{\"$name\":\"Bill Jones\",\"$address_1\":\"2100 Main Street\",\"$address_2\":\"Apt 3B\",\"$city\":\"New London\"," +
+                                 "\"$region\":\"New Hampshire\",\"$country\":\"US\",\"$zipcode\":\"03257\",\"$phone\":\"1-415-555-6040\"}},\"$account_types\":" +
+                                 "[\"merchant\",\"premium\"],\"foo\":\"bar\"}",
                                  createAccount.ToJson());
 
             EventRequest eventRequest = new EventRequest
@@ -694,16 +696,19 @@ namespace Test
                         country = "US",
                         zipcode = "03257"
                     }
-                }
+                },
+                account_types = new ObservableCollection<string>() { "merchant", "premium" }
             };
 
             // Augment with custom fields
             updateAccount.AddField("foo", "bar");
+
             Assert.Equal("{\"$type\":\"$update_account\",\"$user_id\":\"test_dotnet_update_account_event\",\"$session_id\":\"gigtleqddo84l8cm15qe4il\"," +
-                                 "\"$user_email\":\"bill@gmail.com\",\"$name\":\"Bill Jones\",\"$referrer_user_id\":\"janejane101\",\"$social_sign_on_type\":\"$twitter\"," +
-                                 "\"$merchant_profile\":{\"$merchant_id\":\"123\",\"$merchant_category_code\":\"9876\",\"$merchant_name\":\"ABC Merchant\",\"$merchant_address\":" +
-                                 "{\"$name\":\"Bill Jones\",\"$address_1\":\"2100 Main Street\",\"$address_2\":\"Apt 3B\",\"$city\":\"New London\",\"$region\":\"New Hampshire\"," +
-                                 "\"$country\":\"US\",\"$zipcode\":\"03257\",\"$phone\":\"1-415-555-6040\"}},\"foo\":\"bar\"}",
+                                 "\"$user_email\":\"bill@gmail.com\",\"$name\":\"Bill Jones\",\"$referrer_user_id\":\"janejane101\",\"$social_sign_on_type\":" +
+                                 "\"$twitter\",\"$merchant_profile\":{\"$merchant_id\":\"123\",\"$merchant_category_code\":\"9876\",\"$merchant_name\":\"ABC Merchant\"," +
+                                 "\"$merchant_address\":{\"$name\":\"Bill Jones\",\"$address_1\":\"2100 Main Street\",\"$address_2\":\"Apt 3B\",\"$city\":" +
+                                 "\"New London\",\"$region\":\"New Hampshire\",\"$country\":\"US\",\"$zipcode\":\"03257\",\"$phone\":\"1-415-555-6040\"}}," +
+                                 "\"$account_types\":[\"merchant\",\"premium\"],\"foo\":\"bar\"}",
                                  updateAccount.ToJson());
 
             EventRequest eventRequest = new EventRequest

--- a/Test/Test.cs
+++ b/Test/Test.cs
@@ -728,5 +728,56 @@ namespace Test
             Assert.Equal("https://api.sift.com/v205/events?abuse_types=legacy,payment_abuse&return_score=true",
                           Uri.UnescapeDataString(eventRequest.Request.RequestUri.ToString()));
         }
+
+        [Fact]
+        public void TestLoginEvent()
+        {
+            var login = new Login
+            {
+                user_id = "test_dotnet_login_event",
+                session_id = "gigtleqddo84l8cm15qe4il",
+                user_email = "bill@gmail.com",
+                login_status = "$success",
+                ip = "128.148.1.135",
+                failure_reason = "$account_unknown",
+                social_sign_on_type = "$facebook",
+                username = "test_user_name",
+                site_country = "US",
+                site_domain = "sift.com",
+                brand_name = "sift",
+                browser = new Browser
+                {
+                    user_agent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36",
+                    accept_language = "en-US",
+                    content_language = "en-GB"
+                },
+                account_types = new ObservableCollection<string>() { "merchant", "premium" }
+            };
+
+            Assert.Equal("{\"$type\":\"$login\",\"$user_id\":\"test_dotnet_login_event\",\"$session_id\":\"gigtleqddo84l8cm15qe4il\"," +
+                                 "\"$user_email\":\"bill@gmail.com\",\"$login_status\":\"$success\",\"$failure_reason\":\"$account_unknown\"," +
+                                 "\"$social_sign_on_type\":\"$facebook\",\"$username\":\"test_user_name\",\"$ip\":\"128.148.1.135\",\"$browser\":" +
+                                 "{\"$user_agent\":\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_3) AppleWebKit/537.36 (KHTML, like Gecko) " +
+                                 "Chrome/56.0.2924.87 Safari/537.36\",\"$accept_language\":\"en-US\",\"$content_language\":\"en-GB\"},\"$brand_name\":" +
+                                 "\"sift\",\"$site_country\":\"US\",\"$site_domain\":\"sift.com\",\"$account_types\":[\"merchant\",\"premium\"]}",
+                                 login.ToJson());
+
+            EventRequest eventRequest = new EventRequest
+            {
+                Event = login
+            };
+
+            Assert.Equal("https://api.sift.com/v205/events", eventRequest.Request.RequestUri.ToString());
+
+            eventRequest = new EventRequest
+            {
+                Event = login,
+                AbuseTypes = { "legacy", "payment_abuse" },
+                ReturnScore = true
+            };
+
+            Assert.Equal("https://api.sift.com/v205/events?abuse_types=legacy,payment_abuse&return_score=true",
+                          Uri.UnescapeDataString(eventRequest.Request.RequestUri.ToString()));
+        }
     }
 }

--- a/Test/Test.cs
+++ b/Test/Test.cs
@@ -550,5 +550,178 @@ namespace Test
             Assert.Equal("https://api.sift.com/v205/events?abuse_types=legacy,payment_abuse&return_score=true",
                           Uri.UnescapeDataString(eventRequest.Request.RequestUri.ToString()));
         }
+
+        [Fact]
+        public void TestChargebackEvent()
+        {
+            var chargeback = new Chargeback
+            {
+                user_id = "test_dotnet_chargeback_event",
+                session_id = "gigtleqddo84l8cm15qe4il",
+                transaction_id = "719637215",
+                order_id = "ORDER-123124124",
+                chargeback_state = "$lost",
+                chargeback_reason = "$duplicate",
+
+                merchant_profile = new MerchantProfile
+                {
+                    merchant_id = "123",
+                    merchant_category_code = "9876",
+                    merchant_name = "ABC Merchant",
+                    merchant_address = new Address
+                    {
+                        name = "Bill Jones",
+                        phone = "1-415-555-6040",
+                        address_1 = "2100 Main Street",
+                        address_2 = "Apt 3B",
+                        city = "New London",
+                        region = "New Hampshire",
+                        country = "US",
+                        zipcode = "03257"
+                    }
+                }
+            };
+
+            // Augment with custom fields
+            chargeback.AddField("foo", "bar");
+            Assert.Equal("{\"$type\":\"$chargeback\",\"$user_id\":\"test_dotnet_chargeback_event\",\"$session_id\":\"gigtleqddo84l8cm15qe4il\"," +
+                                 "\"$order_id\":\"ORDER-123124124\",\"$transaction_id\":\"719637215\",\"$chargeback_state\":\"$lost\",\"$chargeback_reason\":\"$duplicate\"," +
+                                 "\"$merchant_profile\":{\"$merchant_id\":\"123\",\"$merchant_category_code\":\"9876\",\"$merchant_name\":\"ABC Merchant\",\"$merchant_address\":" +
+                                 "{\"$name\":\"Bill Jones\",\"$address_1\":\"2100 Main Street\",\"$address_2\":\"Apt 3B\",\"$city\":\"New London\",\"$region\":\"New Hampshire\"," +
+                                 "\"$country\":\"US\",\"$zipcode\":\"03257\",\"$phone\":\"1-415-555-6040\"}},\"foo\":\"bar\"}",
+                                 chargeback.ToJson());
+
+            EventRequest eventRequest = new EventRequest
+            {
+                Event = chargeback
+            };
+
+            Assert.Equal("https://api.sift.com/v205/events", eventRequest.Request.RequestUri.ToString());
+
+            eventRequest = new EventRequest
+            {
+                Event = chargeback,
+                AbuseTypes = { "legacy", "payment_abuse" },
+                ReturnScore = true
+            };
+
+            Assert.Equal("https://api.sift.com/v205/events?abuse_types=legacy,payment_abuse&return_score=true",
+                          Uri.UnescapeDataString(eventRequest.Request.RequestUri.ToString()));
+        }
+
+        [Fact]
+        public void TestCreateAccountEvent()
+        {
+            var createAccount = new CreateAccount
+            {
+                user_id = "test_dotnet_create_account_event",
+                session_id = "gigtleqddo84l8cm15qe4il",
+                user_email = "bill@gmail.com",
+                name = "Bill Jones",
+                referrer_user_id = "janejane101",
+                social_sign_on_type = "$twitter",
+                merchant_profile = new MerchantProfile
+                {
+                    merchant_id = "123",
+                    merchant_category_code = "9876",
+                    merchant_name = "ABC Merchant",
+                    merchant_address = new Address
+                    {
+                        name = "Bill Jones",
+                        phone = "1-415-555-6040",
+                        address_1 = "2100 Main Street",
+                        address_2 = "Apt 3B",
+                        city = "New London",
+                        region = "New Hampshire",
+                        country = "US",
+                        zipcode = "03257"
+                    }
+                }
+            };
+
+            // Augment with custom fields
+            createAccount.AddField("foo", "bar");
+
+            Assert.Equal("{\"$type\":\"$create_account\",\"$user_id\":\"test_dotnet_create_account_event\",\"$session_id\":\"gigtleqddo84l8cm15qe4il\"," +
+                                 "\"$user_email\":\"bill@gmail.com\",\"$name\":\"Bill Jones\",\"$referrer_user_id\":\"janejane101\",\"$social_sign_on_type\":\"$twitter\"," +
+                                 "\"$merchant_profile\":{\"$merchant_id\":\"123\",\"$merchant_category_code\":\"9876\",\"$merchant_name\":\"ABC Merchant\",\"$merchant_address\":" +
+                                 "{\"$name\":\"Bill Jones\",\"$address_1\":\"2100 Main Street\",\"$address_2\":\"Apt 3B\",\"$city\":\"New London\",\"$region\":\"New Hampshire\"," +
+                                 "\"$country\":\"US\",\"$zipcode\":\"03257\",\"$phone\":\"1-415-555-6040\"}},\"foo\":\"bar\"}",
+                                 createAccount.ToJson());
+
+            EventRequest eventRequest = new EventRequest
+            {
+                Event = createAccount
+            };
+
+            Assert.Equal("https://api.sift.com/v205/events", eventRequest.Request.RequestUri.ToString());
+
+            eventRequest = new EventRequest
+            {
+                Event = createAccount,
+                AbuseTypes = { "legacy", "payment_abuse" },
+                ReturnScore = true
+            };
+
+            Assert.Equal("https://api.sift.com/v205/events?abuse_types=legacy,payment_abuse&return_score=true",
+                          Uri.UnescapeDataString(eventRequest.Request.RequestUri.ToString()));
+        }
+
+        [Fact]
+        public void TestUpdateAccountEvent()
+        {
+            var updateAccount = new UpdateAccount
+            {
+                user_id = "test_dotnet_update_account_event",
+                session_id = "gigtleqddo84l8cm15qe4il",
+                user_email = "bill@gmail.com",
+                name = "Bill Jones",
+                referrer_user_id = "janejane101",
+                social_sign_on_type = "$twitter",
+                merchant_profile = new MerchantProfile
+                {
+                    merchant_id = "123",
+                    merchant_category_code = "9876",
+                    merchant_name = "ABC Merchant",
+                    merchant_address = new Address
+                    {
+                        name = "Bill Jones",
+                        phone = "1-415-555-6040",
+                        address_1 = "2100 Main Street",
+                        address_2 = "Apt 3B",
+                        city = "New London",
+                        region = "New Hampshire",
+                        country = "US",
+                        zipcode = "03257"
+                    }
+                }
+            };
+
+            // Augment with custom fields
+            updateAccount.AddField("foo", "bar");
+            Assert.Equal("{\"$type\":\"$update_account\",\"$user_id\":\"test_dotnet_update_account_event\",\"$session_id\":\"gigtleqddo84l8cm15qe4il\"," +
+                                 "\"$user_email\":\"bill@gmail.com\",\"$name\":\"Bill Jones\",\"$referrer_user_id\":\"janejane101\",\"$social_sign_on_type\":\"$twitter\"," +
+                                 "\"$merchant_profile\":{\"$merchant_id\":\"123\",\"$merchant_category_code\":\"9876\",\"$merchant_name\":\"ABC Merchant\",\"$merchant_address\":" +
+                                 "{\"$name\":\"Bill Jones\",\"$address_1\":\"2100 Main Street\",\"$address_2\":\"Apt 3B\",\"$city\":\"New London\",\"$region\":\"New Hampshire\"," +
+                                 "\"$country\":\"US\",\"$zipcode\":\"03257\",\"$phone\":\"1-415-555-6040\"}},\"foo\":\"bar\"}",
+                                 updateAccount.ToJson());
+
+            EventRequest eventRequest = new EventRequest
+            {
+                Event = updateAccount
+            };
+
+            Assert.Equal("https://api.sift.com/v205/events", eventRequest.Request.RequestUri.ToString());
+
+            eventRequest = new EventRequest
+            {
+                Event = updateAccount,
+                AbuseTypes = { "legacy", "payment_abuse" },
+                ReturnScore = true
+            };
+
+            Assert.Equal("https://api.sift.com/v205/events?abuse_types=legacy,payment_abuse&return_score=true",
+                          Uri.UnescapeDataString(eventRequest.Request.RequestUri.ToString()));
+        }
     }
 }


### PR DESCRIPTION
**Purpose**
- Adding support for `$merchant_profile` complex field to `$create_account` , `$update_account`, and `$chargeback` events
- Adding support for `$account_types` field in `$create_account` and `$update_account` events

**Technical Overview**
- Updated the schemas for  `$create_account` , `$update_account`, and `$chargeback` events for the above fields.

**Testing Plan**
- [x] Updated unit tests

**Deployment**
- Publish the package using NuGet
