### PR TITLE
Msue 195 remove keyless user id from api contract in sift dotnet

### DIFF
--- a/Sift/Schema/add_item_to_cart.json
+++ b/Sift/Schema/add_item_to_cart.json
@@ -41,9 +41,6 @@
     "$site_domain": {
       "type": [ "string", "null" ]
     },
-    "$keyless_user_id": {
-      "type": [ "string", "null" ]
-    },
     "$verification_phone_number": {
       "type": [ "string", "null" ]
     }

--- a/Sift/Schema/add_promotion.json
+++ b/Sift/Schema/add_promotion.json
@@ -39,9 +39,6 @@
     "$site_domain": {
       "type": [ "string", "null" ]
     },
-    "$keyless_user_id": {
-      "type": [ "string", "null" ]
-    },
     "$verification_phone_number": {
       "type": [ "string", "null" ]
     }

--- a/Sift/Schema/content_status.json
+++ b/Sift/Schema/content_status.json
@@ -41,9 +41,6 @@
     "$site_domain": {
       "type": [ "string", "null" ]
     },
-    "$keyless_user_id": {
-      "type": [ "string", "null" ]
-    },
     "$verification_phone_number": {
       "type": [ "string", "null" ]
     }

--- a/Sift/Schema/create_account.json
+++ b/Sift/Schema/create_account.json
@@ -80,9 +80,6 @@
         "type": [ "array", "null" ],
         "items": { "type": "string" }
     },
-    "$keyless_user_id": {
-      "type": [ "string", "null" ]
-    },
     "$verification_phone_number": {
       "type": [ "string", "null" ]
     }

--- a/Sift/Schema/create_content.json
+++ b/Sift/Schema/create_content.json
@@ -80,9 +80,6 @@
     "$site_domain": {
       "type": [ "string", "null" ]
     },
-    "$keyless_user_id": {
-      "type": [ "string", "null" ]
-    },
     "$verification_phone_number": {
       "type": [ "string", "null" ]
     }

--- a/Sift/Schema/create_order.json
+++ b/Sift/Schema/create_order.json
@@ -100,9 +100,6 @@
     "$digital_orders": {
       "type": [ "array", "null" ],
       "items": { "$ref": "ComplexTypes/digital_order.json" }
-    },
-    "$keyless_user_id": {
-      "type": [ "string", "null" ]
     }
   }
 }

--- a/Sift/Schema/custom_event.json
+++ b/Sift/Schema/custom_event.json
@@ -21,9 +21,6 @@
     "$site_domain": {
       "type": [ "string", "null" ]
     },
-    "$keyless_user_id": {
-      "type": [ "string", "null" ]
-    },
     "$verification_phone_number": {
       "type": [ "string", "null" ]
     }

--- a/Sift/Schema/login.json
+++ b/Sift/Schema/login.json
@@ -57,9 +57,6 @@
         "type": [ "array", "null" ],
         "items": { "type": "string" }
     },
-    "$keyless_user_id": {
-      "type": [ "string", "null" ]
-    },
     "$verification_phone_number": {
       "type": [ "string", "null" ]
     }

--- a/Sift/Schema/logout.json
+++ b/Sift/Schema/logout.json
@@ -31,9 +31,6 @@
     },
     "$site_domain": {
       "type": [ "string", "null" ]
-    },
-    "$keyless_user_id": {
-      "type": [ "string", "null" ]
     }
   }
 }

--- a/Sift/Schema/order_status.json
+++ b/Sift/Schema/order_status.json
@@ -55,9 +55,6 @@
     },
     "$site_domain": {
       "type": [ "string", "null" ]
-    },
-    "$keyless_user_id": {
-      "type": [ "string", "null" ]
     }
   }
 }

--- a/Sift/Schema/remove_item_from_cart.json
+++ b/Sift/Schema/remove_item_from_cart.json
@@ -41,9 +41,6 @@
     "$site_domain": {
       "type": [ "string", "null" ]
     },
-    "$keyless_user_id": {
-      "type": [ "string", "null" ]
-    },
     "$verification_phone_number": {
       "type": [ "string", "null" ]
     }

--- a/Sift/Schema/security_notification.json
+++ b/Sift/Schema/security_notification.json
@@ -43,9 +43,6 @@
     },
     "$site_domain": {
       "type": [ "string", "null" ]
-    },
-    "$keyless_user_id": {
-      "type": [ "string", "null" ]
     }
   }
 }

--- a/Sift/Schema/transaction.json
+++ b/Sift/Schema/transaction.json
@@ -127,9 +127,6 @@
     "$receiver_external_address": {
       "type": [ "boolean", "null" ]
     },
-    "$keyless_user_id": {
-      "type": [ "string", "null" ]
-    },
     "$verification_phone_number": {
       "type": [ "string", "null" ]
     }

--- a/Sift/Schema/update_account.json
+++ b/Sift/Schema/update_account.json
@@ -79,9 +79,6 @@
         "type": [ "array", "null" ],
         "items": { "type": "string" }
     },
-    "$keyless_user_id": {
-      "type": [ "string", "null" ]
-    },
     "$verification_phone_number": {
       "type": [ "string", "null" ]
     }

--- a/Sift/Schema/update_order.json
+++ b/Sift/Schema/update_order.json
@@ -91,9 +91,6 @@
         { "type": "null" }
       ]
     },
-    "$keyless_user_id": {
-      "type": [ "string", "null" ]
-    },
     "$verification_phone_number": {
       "type": [ "string", "null" ]
     },

--- a/Test/Test.cs
+++ b/Test/Test.cs
@@ -155,7 +155,6 @@ namespace Test
                 },
                 site_country = "US",
                 site_domain = "sift.com",
-                keyless_user_id = "keylessId",
                 brand_name = "sift"
             };
 
@@ -179,7 +178,7 @@ namespace Test
                          "\"$app_version\":\"1.0\",\"$client_language\":\"en-US\"},\"$brand_name\":\"sift\",\"$site_country\":\"US\",\"$site_domain\":\"sift.com\"," +
                          "\"$ordered_from\":{\"$store_id\":\"123\",\"$store_address\":{\"$name\":\"Bill Jones\",\"$address_1\":\"2100 Main Street\"," +
                          "\"$address_2\":\"Apt 3B\",\"$city\":\"New London\",\"$region\":\"New Hampshire\",\"$country\":\"US\",\"$zipcode\":\"03257\"," +
-                         "\"$phone\":\"1-415-555-6040\"}},\"$keyless_user_id\":\"keylessId\",\"foo\":\"bar\"}",
+                         "\"$phone\":\"1-415-555-6040\"}},\"foo\":\"bar\"}",
                          createOrder.ToJson());
 
 
@@ -1281,7 +1280,6 @@ namespace Test
                 username = "test_user_name",
                 site_country = "US",
                 site_domain = "sift.com",
-                keyless_user_id = "keylessId",
                 brand_name = "sift",
                 browser = new Browser
                 {
@@ -1297,7 +1295,7 @@ namespace Test
                                  "\"$social_sign_on_type\":\"$facebook\",\"$username\":\"test_user_name\",\"$ip\":\"128.148.1.135\",\"$browser\":" +
                                  "{\"$user_agent\":\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_3) AppleWebKit/537.36 (KHTML, like Gecko) " +
                                  "Chrome/56.0.2924.87 Safari/537.36\",\"$accept_language\":\"en-US\",\"$content_language\":\"en-GB\"},\"$brand_name\":" +
-                                 "\"sift\",\"$site_country\":\"US\",\"$site_domain\":\"sift.com\",\"$account_types\":[\"merchant\",\"premium\"]," + "\"$keyless_user_id\":\"keylessId\"" + "}",
+                                 "\"sift\",\"$site_country\":\"US\",\"$site_domain\":\"sift.com\",\"$account_types\":[\"merchant\",\"premium\"]}" ,
                                  login.ToJson());
 
             EventRequest eventRequest = new EventRequest


### PR DESCRIPTION
## Purpose
We gonna turn off the Keyless Connector so makes sense to remove the parameter from our API Contract in sift-dotnet client

## Summary
Remove all reference related to Keyless Connector in sift-dotnet client
 
## Testing

## Checklist
- [x] The change was thoroughly tested manually
- [x] The change was covered with unit tests
- [x] The applicable unit tests were updated
- [x] The change was tested with real API calls (if applicable)
- [x] Necessary changes were made in the integration tests (if applicable)
- [ ] New functionality is reflected in README
