### PR TITLE
Msue 196

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,8 +210,61 @@ The official Sift .NET client, supporting .NET Standard 2.0+
             }
         }
 
+        // Construct reserved events with known fields for UpdateContent.Message
+    var updateContent = new UpdateContent
+            {
+                user_id = "fyw3989sjpqr71",
+                content_id = "message-23412",
+                session_id = "a234ksjfgn435sfg",
+                status = "$active",
+                ip = "255.255.255.0",
+                message = new Message()
+                {
+                    body = "Let’s meet at 5pm",
+                    contact_email = "alex_301@domain.com",
+                    root_content_id = "listing-123",
+                    recipient_user_ids = new ObservableCollection<string>() { "fy9h989sjphh71" },
+                    images = new ObservableCollection<Image>()
+                    {
+                        new Image()
+                        {
+                            md5_hash = "0cc175b9c0f1b6a831c399e269772661",
+                            link = "https://www.domain.com/file.png",
+                            description =   "My hike today!"
+                        },
+                        new Image()
+                        {
+                            md5_hash = "0cc175b9c0f1b6a831c399e269772661"
+                        }
+                    },
+                },
+                browser = new Browser
+                {
+                    user_agent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36",
+                    accept_language = "en-US",
+                    content_language = "en-GB"
+                },
+                brand_name = "sift",
+                site_country = "US",
+                site_domain = "sift.com",
+            };
+
+            EventRequest eventRequest = new EventRequest()
+            {
+                Event = updateContent
+            };
+            try
+            {
+                EventResponse res = sift.SendAsync(eventRequest).Result;
+            }
+            catch (AggregateException ae)
+            {
+                // Handle InnerException
+            }
+        }
 
 
+    
 #### IncludeScorePercentile in EventRequest
 
       EventRequest eventRequest = new EventRequest

--- a/README.md
+++ b/README.md
@@ -105,7 +105,112 @@ The official Sift .NET client, supporting .NET Standard 2.0+
         }
 
 
-    
+    // Construct reserved events with known fields for UpdateContent.Listing
+                var updateContent = new UpdateContent
+            {
+                user_id = "fyw3989sjpqr71",
+                content_id = "listing-23412",
+                session_id = "a234ksjfgn435sfg",
+                status = "$active",
+                ip = "255.255.255.0",
+                browser = new Browser
+                {
+                    user_agent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36",
+                    accept_language = "en-US",
+                    content_language = "en-GB"
+                },
+                listing = new Listing()
+                {
+                    subject = "2 Bedroom Apartment for Rent",
+                    body = "Capitol Hill Seattle brand new condo. 2 bedrooms and 1 full bath.",
+                    contact_email = "alex_301@domain.com",
+                    contact_address = new Address()
+                    {
+                        name = "Bill Jones",
+                        address_1 = "abc",
+                        address_2 = "xyz",
+                        city = "New London",
+                        region = "New Hampshire",
+                        country = "US",
+                        zipcode = "03257",
+                        phone = "1-415-555-6041"
+
+
+                    },
+                    locations = new ObservableCollection<Address>()
+                    {
+                        new Address()
+                        {
+                            name = "Bill Jones",
+                            address_1 = "abc",
+                            address_2 = "xyz",
+                            city = "Seattle",
+                            region = "Washington",
+                            country = "US",
+                            zipcode = "98112",
+                            phone = "1-415-555-6041"
+                        },
+                        new Address()
+                        {
+                            name = "Bill Jones"
+                        }
+
+                    },
+                    listed_items = new ObservableCollection<Item>()
+                    {
+                        new Item()
+                        {
+                            item_id = "0cc175b9c0f1b6a831c399e269772661",
+                            product_title = "https://www.domain.com/file.png",
+                            price = 2950000000,
+                            currency_code = "USD",
+                            quantity = 1,
+                            upc = "6786211451001",
+                            sku = "abc",
+                            isbn = "0446576220",
+                            brand = "abc",
+                            manufacturer = "abc",
+                            category = "abc",
+                            tags = new ObservableCollection<string>() { "heat","washer/dryer" },
+                            color = "ab",
+                            size = "ab"
+                        }
+                    },
+                    images = new ObservableCollection<Image>()
+                    {
+                        new Image()
+                        {
+                            md5_hash = "0cc175b9c0f1b6a831c399e269772661",
+                            link = "https://www.domain.com/file.png",
+                            description =   "Billy's picture"
+                        },
+                        new Image()
+                        {
+                            md5_hash = "0cc175b9c0f1b6a831c399e269772661"
+                        }
+                    },
+                    expiration_time = 1549063157000
+                },
+                brand_name = "sift",
+                site_country = "US",
+                site_domain = "sift.com",
+            };
+
+            EventRequest eventRequest = new EventRequest()
+            {
+                Event = updateContent
+            };
+            try
+            {
+                EventResponse res = sift.SendAsync(eventRequest).Result;
+            }
+            catch (AggregateException ae)
+            {
+                // Handle InnerException
+            }
+        }
+
+
 
 #### IncludeScorePercentile in EventRequest
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,63 @@ The official Sift .NET client, supporting .NET Standard 2.0+
         // Handle InnerException
     }
 
+
+    // Construct reserved events with known fields for UpdateContent.Comment
+    var updateContent = new UpdateContent
+            {
+                user_id = "fyw3989sjpqr71",
+                content_id = "comment-23412",
+                session_id = "a234ksjfgn435sfg",
+                status = "$active",
+                ip = "255.255.255.0",
+                browser = new Browser
+                {
+                    user_agent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36",
+                    accept_language = "en-US",
+                    content_language = "en-GB"
+                },
+                comment = new Comment()
+                {
+                    body = "Congrats on the new role!",
+                    contact_email = "alex_301@domain.com",
+                    parent_comment_id = "comment-23407",
+                    root_content_id = "listing-12923213",
+                    images = new ObservableCollection<Image>()
+                    {
+                        new Image()
+                        {
+                            md5_hash = "0cc175b9c0f1b6a831c399e269772661",
+                            link = "https://www.domain.com/file.png",
+                            description =   "An old picture"
+                        },
+                        new Image()
+                        {
+                            md5_hash = "0cc175b9c0f1b6a831c399e269772661"
+                        }
+                    }
+                },
+                brand_name = "sift",
+                site_country = "US",
+                site_domain = "sift.com",
+            };
+
+            EventRequest eventRequest = new EventRequest()
+            {
+                Event = updateContent
+            };
+            try
+            {
+                EventResponse res = sift.SendAsync(eventRequest).Result;
+            }
+            catch (AggregateException ae)
+            {
+                // Handle InnerException
+            }
+        }
+
+
+    
+
 #### IncludeScorePercentile in EventRequest
 
       EventRequest eventRequest = new EventRequest

--- a/README.md
+++ b/README.md
@@ -105,8 +105,8 @@ The official Sift .NET client, supporting .NET Standard 2.0+
         }
 
 
-    // Construct reserved events with known fields for UpdateContent.Listing
-                var updateContent = new UpdateContent
+        // Construct reserved events with known fields for UpdateContent.Listing
+        var updateContent = new UpdateContent
             {
                 user_id = "fyw3989sjpqr71",
                 content_id = "listing-23412",
@@ -211,7 +211,7 @@ The official Sift .NET client, supporting .NET Standard 2.0+
         }
 
         // Construct reserved events with known fields for UpdateContent.Message
-    var updateContent = new UpdateContent
+        var updateContent = new UpdateContent
             {
                 user_id = "fyw3989sjpqr71",
                 content_id = "message-23412",
@@ -264,8 +264,8 @@ The official Sift .NET client, supporting .NET Standard 2.0+
         }
 
 
-    // Construct reserved events with known fields for UpdateContent.Post
-    var updateContent = new UpdateContent
+        // Construct reserved events with known fields for UpdateContent.Post
+        var updateContent = new UpdateContent
             {
                 user_id = "fyw3989sjpqr71",
                 content_id = "post-23412",
@@ -349,7 +349,7 @@ The official Sift .NET client, supporting .NET Standard 2.0+
         }
 
         // Construct reserved events with known fields for UpdateContent.Profile
-    var updateContent = new UpdateContent
+        var updateContent = new UpdateContent
             {
                 user_id = "fyw3989sjpqr71",
                 content_id = "listing-23412",
@@ -385,6 +385,96 @@ The official Sift .NET client, supporting .NET Standard 2.0+
                         }
                     },
                     categories = new ObservableCollection<string>() { "Friends", "Long-term dating" }
+                },
+                browser = new Browser
+                {
+                    user_agent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36",
+                    accept_language = "en-US",
+                    content_language = "en-GB"
+                },
+                brand_name = "sift",
+                site_country = "US",
+                site_domain = "sift.com",
+            };
+
+            EventRequest eventRequest = new EventRequest()
+            {
+                Event = updateContent
+            };
+            try
+            {
+                EventResponse res = sift.SendAsync(eventRequest).Result;
+            }
+            catch (AggregateException ae)
+            {
+                // Handle InnerException
+            }
+        }
+
+        // Construct reserved events with known fields for UpdateContent.Review
+        var updateContent = new UpdateContent
+            {
+                user_id = "fyw3989sjpqr71",
+                content_id = "review-23412",
+                session_id = "a234ksjfgn435sfg",
+                status = "$active",
+                ip = "255.255.255.0",
+                review = new Review()
+                {
+                    subject = "Amazing Tacos!",
+                    body = "I ate the tacos.",
+                    contact_email = "alex_301@domain.com",
+                    locations = new ObservableCollection<Address>()
+                    {
+                        new Address()
+                        {
+                            name = "Bill Jones",
+                            address_1 = "abc",
+                            address_2 = "xyz",
+                            city = "Seattle",
+                            region = "Washington",
+                            country = "US",
+                            zipcode = "98112",
+                            phone = "1-415-555-6041"
+                        },
+                        new Address()
+                        {
+                            name = "Bill Jones"
+                        }
+
+                    },
+                    item_reviewed = new Item()
+                    {
+                        item_id = "B004834GQO",
+                        product_title = "The Slanket Blanket-Texas Tea",
+                        price = 39990000,
+                        currency_code = "USD",
+                        upc = "6786211451001",
+                        sku = "004834GQ",
+                        isbn = "0446576220",
+                        brand = "Slanket",
+                        manufacturer = "Slanket",
+                        category = "Blankets & Throws",
+                        tags = new ObservableCollection<string>() { "Awesome", "Wintertime specials" },
+                        color = "Texas Tea",
+                        size = "6",
+                    },
+
+                    reviewed_content_id = "listing-234234",
+                    rating = 4.5,
+                    images = new ObservableCollection<Image>()
+                    {
+                        new Image()
+                        {
+                            md5_hash = "0cc175b9c0f1b6a831c399e269772661",
+                            link = "https://www.domain.com/file.png",
+                            description = "Calamari tacos."
+                        },
+                        new Image()
+                        {
+                            md5_hash = "0cc175b9c0f1b6a831c399e269772661"
+                        }
+                    },
                 },
                 browser = new Browser
                 {

--- a/README.md
+++ b/README.md
@@ -264,7 +264,92 @@ The official Sift .NET client, supporting .NET Standard 2.0+
         }
 
 
-    
+    // Construct reserved events with known fields for UpdateContent.Post
+    var updateContent = new UpdateContent
+            {
+                user_id = "fyw3989sjpqr71",
+                content_id = "post-23412",
+                session_id = "a234ksjfgn435sfg",
+                status = "$active",
+                ip = "255.255.255.0",
+                browser = new Browser
+                {
+                    user_agent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36",
+                    accept_language = "en-US",
+                    content_language = "en-GB"
+                },
+                post = new Post()
+                {
+                    subject = "My new apartment!",
+                    body = "Moved into my new apartment yesterday.",
+                    contact_email = "alex_301@domain.com",
+                    contact_address = new Address()
+                    {
+                        name = "Bill Jones",
+                        address_1 = "abc",
+                        address_2 = "xyz",
+                        city = "New London",
+                        region = "New Hampshire",
+                        country = "US",
+                        zipcode = "03257",
+                        phone = "1-415-555-6041"
+                    },
+                    locations = new ObservableCollection<Address>()
+                    {
+                        new Address()
+                        {
+                            name = "Bill Jones",
+                            address_1 = "abc",
+                            address_2 = "xyz",
+                            city = "Seattle",
+                            region = "Washington",
+                            country = "US",
+                            zipcode = "98112",
+                            phone = "1-415-555-6041"
+                        },
+                        new Address()
+                        {
+                            name = "Bill Jones"
+                        }
+
+                    },
+                    categories = new ObservableCollection<string>() { "Personal" },
+                    images = new ObservableCollection<Image>()
+                    {
+                        new Image()
+                        {
+                            md5_hash = "0cc175b9c0f1b6a831c399e269772661",
+                            link = "https://www.domain.com/file.png",
+                            description =   "View from the window!"
+                        },
+                        new Image()
+                        {
+                            md5_hash = "0cc175b9c0f1b6a831c399e269772661"
+                        }
+                    },
+                    expiration_time = 1549063157000
+                },
+                brand_name = "sift",
+                site_country = "US",
+                site_domain = "sift.com",
+            };
+
+            EventRequest eventRequest = new EventRequest()
+            {
+                Event = updateContent
+            };
+            try
+            {
+                EventResponse res = sift.SendAsync(eventRequest).Result;
+            }
+            catch (AggregateException ae)
+            {
+                // Handle InnerException
+            }
+        }
+
+
+
 #### IncludeScorePercentile in EventRequest
 
       EventRequest eventRequest = new EventRequest

--- a/README.md
+++ b/README.md
@@ -348,7 +348,68 @@ The official Sift .NET client, supporting .NET Standard 2.0+
             }
         }
 
+        // Construct reserved events with known fields for UpdateContent.Profile
+    var updateContent = new UpdateContent
+            {
+                user_id = "fyw3989sjpqr71",
+                content_id = "listing-23412",
+                session_id = "a234ksjfgn435sfg",
+                status = "$active",
+                ip = "255.255.255.0",
+                profile = new Profile()
+                {
+                    body = "Hi! My name is Alex and I just moved to New London!",
+                    contact_email = "alex_301@domain.com",
+                    contact_address = new Address()
+                    {
+                        name = "Alex Smith",
+                        address_1 = "abc",
+                        address_2 = "xyz",
+                        city = "New London",
+                        region = "New Hampshire",
+                        country = "US",
+                        zipcode = "03257",
+                        phone = "1-415-555-6041"
+                    },
+                    images = new ObservableCollection<Image>()
+                    {
+                        new Image()
+                        {
+                            md5_hash = "0cc175b9c0f1b6a831c399e269772661",
+                            link = "https://www.domain.com/file.png",
+                            description = "Alex’s picture"
+                        },
+                        new Image()
+                        {
+                            md5_hash = "0cc175b9c0f1b6a831c399e269772661"
+                        }
+                    },
+                    categories = new ObservableCollection<string>() { "Friends", "Long-term dating" }
+                },
+                browser = new Browser
+                {
+                    user_agent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36",
+                    accept_language = "en-US",
+                    content_language = "en-GB"
+                },
+                brand_name = "sift",
+                site_country = "US",
+                site_domain = "sift.com",
+            };
 
+            EventRequest eventRequest = new EventRequest()
+            {
+                Event = updateContent
+            };
+            try
+            {
+                EventResponse res = sift.SendAsync(eventRequest).Result;
+            }
+            catch (AggregateException ae)
+            {
+                // Handle InnerException
+            }
+        }
 
 #### IncludeScorePercentile in EventRequest
 

--- a/Sift/Schema/update_content.json
+++ b/Sift/Schema/update_content.json
@@ -1,0 +1,84 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema",
+  "title": "UpdateContent",
+  "type": "object",
+  "required": [ "$type" ],
+  "properties": {
+    "$type": {
+      "type": "string",
+      "default": "$update_content"
+    },
+    "$user_id": {
+      "type": [ "string", "null" ]
+    },
+    "$content_id": {
+      "type": [ "string", "null" ]
+    },
+    "$session_id": {
+      "type": [ "string", "null" ]
+    },
+    "$status": {
+      "type": [ "string", "null" ]
+    },
+    "$ip": {
+      "type": [ "string", "null" ]
+    },
+    "$comment": {
+      "oneOf": [
+        { "$ref": "ComplexTypes/comment.json" },
+        { "type": "null" }
+      ]
+    },
+    "$listing": {
+      "oneOf": [
+        { "$ref": "ComplexTypes/listing.json" },
+        { "type": "null" }
+      ]
+    },
+    "$message": {
+      "oneOf": [
+        { "$ref": "ComplexTypes/message.json" },
+        { "type": "null" }
+      ]
+    },
+    "$post": {
+      "oneOf": [
+        { "$ref": "ComplexTypes/post.json" },
+        { "type": "null" }
+      ]
+    },
+    "$profile": {
+      "oneOf": [
+        { "$ref": "ComplexTypes/profile.json" },
+        { "type": "null" }
+      ]
+    },
+    "$review": {
+      "oneOf": [
+        { "$ref": "ComplexTypes/review.json" },
+        { "type": "null" }
+      ]
+    },
+    "$app": {
+      "oneOf": [
+        { "$ref": "ComplexTypes/app.json" },
+        { "type": "null" }
+      ]
+    },
+    "$browser": {
+      "oneOf": [
+        { "$ref": "ComplexTypes/browser.json" },
+        { "type": "null" }
+      ]
+    },
+    "$brand_name": {
+      "type": [ "string", "null" ]
+    },
+    "$site_country": {
+      "type": [ "string", "null" ]
+    },
+    "$site_domain": {
+      "type": [ "string", "null" ]
+    }
+  }
+}

--- a/Test/Test.cs
+++ b/Test/Test.cs
@@ -1604,5 +1604,103 @@ namespace Test
                           Uri.UnescapeDataString(eventRequest.Request.RequestUri.ToString()));
         }
 
+        //UpdateContentPost
+
+
+        [Fact]
+        public void TestUpdateContentPost()
+        {
+            var sessionId = "sessionId";
+            var updateContent = new UpdateContent
+            {
+                user_id = "fyw3989sjpqr71",
+                content_id = "post-23412",
+                session_id = "a234ksjfgn435sfg",
+                status = "$active",
+                ip = "255.255.255.0",
+                browser = new Browser
+                {
+                    user_agent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36",
+                    accept_language = "en-US",
+                    content_language = "en-GB"
+                },
+                post = new Post()
+                {
+                    subject = "My new apartment!",
+                    body = "Moved into my new apartment yesterday.",
+                    contact_email = "alex_301@domain.com",
+                    contact_address = new Address()
+                    {
+                        name = "Bill Jones",
+                        address_1 = "abc",
+                        address_2 = "xyz",
+                        city = "New London",
+                        region = "New Hampshire",
+                        country = "US",
+                        zipcode = "03257",
+                        phone = "1-415-555-6041"
+                    },
+                    locations = new ObservableCollection<Address>()
+                    {
+                        new Address()
+                        {
+                            name = "Bill Jones",
+                            address_1 = "abc",
+                            address_2 = "xyz",
+                            city = "Seattle",
+                            region = "Washington",
+                            country = "US",
+                            zipcode = "98112",
+                            phone = "1-415-555-6041"
+                        },
+                        new Address()
+                        {
+                            name = "Bill Jones"
+                        }
+
+                    },
+                    categories = new ObservableCollection<string>() { "Personal" },
+                    images = new ObservableCollection<Image>()
+                    {
+                        new Image()
+                        {
+                            md5_hash = "0cc175b9c0f1b6a831c399e269772661",
+                            link = "https://www.domain.com/file.png",
+                            description =   "View from the window!"
+                        },
+                        new Image()
+                        {
+                            md5_hash = "0cc175b9c0f1b6a831c399e269772661"
+                        }
+                    },
+                    expiration_time = 1549063157000
+                },
+                brand_name = "sift",
+                site_country = "US",
+                site_domain = "sift.com",
+            };
+
+            string updatePostBody = "{\"$type\":\"$update_content\",\"$user_id\":\"fyw3989sjpqr71\",\"$content_id\":\"post-23412\",\"$session_id\":\"a234ksjfgn435sfg\",\"$status\":\"$active\",\"$ip\":\"255.255.255.0\",\"$post\":{\"$subject\":\"My new apartment!\",\"$body\":\"Moved into my new apartment yesterday.\",\"$contact_email\":\"alex_301@domain.com\",\"$contact_address\":{\"$name\":\"Bill Jones\",\"$address_1\":\"abc\",\"$address_2\":\"xyz\",\"$city\":\"New London\",\"$region\":\"New Hampshire\",\"$country\":\"US\",\"$zipcode\":\"03257\",\"$phone\":\"1-415-555-6041\"},\"$locations\":[{\"$name\":\"Bill Jones\",\"$address_1\":\"abc\",\"$address_2\":\"xyz\",\"$city\":\"Seattle\",\"$region\":\"Washington\",\"$country\":\"US\",\"$zipcode\":\"98112\",\"$phone\":\"1-415-555-6041\"},{\"$name\":\"Bill Jones\"}],\"$categories\":[\"Personal\"],\"$images\":[{\"$md5_hash\":\"0cc175b9c0f1b6a831c399e269772661\",\"$link\":\"https://www.domain.com/file.png\",\"$description\":\"View from the window!\"},{\"$md5_hash\":\"0cc175b9c0f1b6a831c399e269772661\"}],\"$expiration_time\":1549063157000},\"$browser\":{\"$user_agent\":\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36\",\"$accept_language\":\"en-US\",\"$content_language\":\"en-GB\"},\"$brand_name\":\"sift\",\"$site_country\":\"US\",\"$site_domain\":\"sift.com\"}";
+
+            Assert.Equal(updatePostBody, updateContent.ToJson());
+
+            EventRequest eventRequest = new EventRequest
+            {
+                Event = updateContent
+            };
+
+            Assert.Equal("https://api.sift.com/v205/events", eventRequest.Request.RequestUri.ToString());
+
+            eventRequest = new EventRequest
+            {
+                Event = updateContent,
+                AbuseTypes = { "legacy", "payment_abuse" },
+                ReturnScore = true
+            };
+
+            Assert.Equal("https://api.sift.com/v205/events?abuse_types=legacy,payment_abuse&return_score=true",
+                          Uri.UnescapeDataString(eventRequest.Request.RequestUri.ToString()));
+        }
+
     }
 }

--- a/Test/Test.cs
+++ b/Test/Test.cs
@@ -1316,7 +1316,7 @@ namespace Test
 
             Assert.Equal("https://api.sift.com/v205/events?abuse_types=legacy,payment_abuse&return_score=true",
                           Uri.UnescapeDataString(eventRequest.Request.RequestUri.ToString()));
-        } 
+        }
 
         [Fact]
         public void TestScorePercentile()
@@ -1350,10 +1350,10 @@ namespace Test
 
 
         [Fact]
-        public void TestUpdateContentCommentEvent()
+        public void TestUpdateContentComment()
         {
             var sessionId = "sessionId";
-            var updateContent = new UpdateContentComment
+            var updateContent= new UpdateContent
             {
                 user_id = "fyw3989sjpqr71",
                 content_id = "comment-23412",
@@ -1377,8 +1377,8 @@ namespace Test
                         new Image()
                         {
                             md5_hash = "0cc175b9c0f1b6a831c399e269772661",
-                            link = "https://www.example.com/file.png",
-                            description =   "Example picture"
+                            link = "https://www.domain.com/file.png",
+                            description =   "An old picture"
                         },
                         new Image()
                         {
@@ -1391,19 +1391,20 @@ namespace Test
                 site_domain = "sift.com",
             };
 
-            Assert.Equal("{\"$type\":\"$verification\",\"$user_id\":\"billy_jones_301\",\"$session_id\":\"sessionId\",\"$status\":\"$pending\",\"$browser\":{\"$user_agent\":\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36\",\"$accept_language\":\"en-GB\",\"$content_language\":\"en-US\"},\"$verified_event\":\"$login\",\"$verified_entity_id\":\"123\",\"$verification_type\":\"$sms\",\"$verified_value\":\"14155551212\",\"$reason\":\"$user_setting\",\"$brand_name\":\"xyz\",\"$site_country\":\"AU\",\"$site_domain\":\"somehost.example.com\"}",
-                                 verification.ToJson());
+            string updateCommentBody = "{\"$type\":\"$update_content\",\"$user_id\":\"fyw3989sjpqr71\",\"$content_id\":\"comment-23412\",\"$session_id\":\"a234ksjfgn435sfg\",\"$status\":\"$active\",\"$ip\":\"255.255.255.0\",\"$comment\":{\"$body\":\"Congrats on the new role!\",\"$contact_email\":\"alex_301@domain.com\",\"$parent_comment_id\":\"comment-23407\",\"$root_content_id\":\"listing-12923213\",\"$images\":[{\"$md5_hash\":\"0cc175b9c0f1b6a831c399e269772661\",\"$link\":\"https://www.domain.com/file.png\",\"$description\":\"An old picture\"},{\"$md5_hash\":\"0cc175b9c0f1b6a831c399e269772661\"}]},\"$browser\":{\"$user_agent\":\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36\",\"$accept_language\":\"en-US\",\"$content_language\":\"en-GB\"},\"$brand_name\":\"sift\",\"$site_country\":\"US\",\"$site_domain\":\"sift.com\"}";
+
+            Assert.Equal(updateCommentBody, updateContent.ToJson());
 
             EventRequest eventRequest = new EventRequest
             {
-                Event = UpdateContentComment
+                Event = updateContent
             };
 
             Assert.Equal("https://api.sift.com/v205/events", eventRequest.Request.RequestUri.ToString());
 
             eventRequest = new EventRequest
             {
-                Event = UpdateContentComment,
+                Event = updateContent,
                 AbuseTypes = { "legacy", "payment_abuse" },
                 ReturnScore = true
             };

--- a/Test/Test.cs
+++ b/Test/Test.cs
@@ -1582,9 +1582,9 @@ namespace Test
                 site_domain = "sift.com",
             };
 
-            string updateListingBody = "{\"$type\":\"$update_content\",\"$user_id\":\"fyw3989sjpqr71\",\"$content_id\":\"message-23412\",\"$session_id\":\"a234ksjfgn435sfg\",\"$status\":\"$active\",\"$ip\":\"255.255.255.0\",\"$message\":{\"$body\":\"Let’s meet at 5pm\",\"$contact_email\":\"alex_301@domain.com\",\"$root_content_id\":\"listing-123\",\"$recipient_user_ids\":[\"fy9h989sjphh71\"],\"$images\":[{\"$md5_hash\":\"0cc175b9c0f1b6a831c399e269772661\",\"$link\":\"https://www.domain.com/file.png\",\"$description\":\"My hike today!\"},{\"$md5_hash\":\"0cc175b9c0f1b6a831c399e269772661\"}]},\"$browser\":{\"$user_agent\":\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36\",\"$accept_language\":\"en-US\",\"$content_language\":\"en-GB\"},\"$brand_name\":\"sift\",\"$site_country\":\"US\",\"$site_domain\":\"sift.com\"}";
+            string updateMessageBody = "{\"$type\":\"$update_content\",\"$user_id\":\"fyw3989sjpqr71\",\"$content_id\":\"message-23412\",\"$session_id\":\"a234ksjfgn435sfg\",\"$status\":\"$active\",\"$ip\":\"255.255.255.0\",\"$message\":{\"$body\":\"Let’s meet at 5pm\",\"$contact_email\":\"alex_301@domain.com\",\"$root_content_id\":\"listing-123\",\"$recipient_user_ids\":[\"fy9h989sjphh71\"],\"$images\":[{\"$md5_hash\":\"0cc175b9c0f1b6a831c399e269772661\",\"$link\":\"https://www.domain.com/file.png\",\"$description\":\"My hike today!\"},{\"$md5_hash\":\"0cc175b9c0f1b6a831c399e269772661\"}]},\"$browser\":{\"$user_agent\":\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36\",\"$accept_language\":\"en-US\",\"$content_language\":\"en-GB\"},\"$brand_name\":\"sift\",\"$site_country\":\"US\",\"$site_domain\":\"sift.com\"}";
 
-            Assert.Equal(updateListingBody, updateContent.ToJson());
+            Assert.Equal(updateMessageBody, updateContent.ToJson());
 
             EventRequest eventRequest = new EventRequest
             {

--- a/Test/Test.cs
+++ b/Test/Test.cs
@@ -1535,5 +1535,74 @@ namespace Test
             Assert.Equal("https://api.sift.com/v205/events?abuse_types=legacy,payment_abuse&return_score=true",
                           Uri.UnescapeDataString(eventRequest.Request.RequestUri.ToString()));
         }
+
+
+        //UpdateContentMessage
+
+
+        [Fact]
+        public void TestUpdateContentMessage()
+        {
+            var sessionId = "sessionId";
+            var updateContent = new UpdateContent
+            {
+                user_id = "fyw3989sjpqr71",
+                content_id = "message-23412",
+                session_id = "a234ksjfgn435sfg",
+                status = "$active",
+                ip = "255.255.255.0",                
+                message = new Message()
+                {
+                    body = "Let’s meet at 5pm",
+                    contact_email = "alex_301@domain.com",
+                    root_content_id = "listing-123",
+                    recipient_user_ids = new ObservableCollection<string>() { "fy9h989sjphh71"},
+                    images = new ObservableCollection<Image>()
+                    {
+                        new Image()
+                        {
+                            md5_hash = "0cc175b9c0f1b6a831c399e269772661",
+                            link = "https://www.domain.com/file.png",
+                            description =   "My hike today!"
+                        },
+                        new Image()
+                        {
+                            md5_hash = "0cc175b9c0f1b6a831c399e269772661"
+                        }
+                    },
+                },
+                browser = new Browser
+                {
+                    user_agent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36",
+                    accept_language = "en-US",
+                    content_language = "en-GB"
+                },
+                brand_name = "sift",
+                site_country = "US",
+                site_domain = "sift.com",
+            };
+
+            string updateListingBody = "{\"$type\":\"$update_content\",\"$user_id\":\"fyw3989sjpqr71\",\"$content_id\":\"message-23412\",\"$session_id\":\"a234ksjfgn435sfg\",\"$status\":\"$active\",\"$ip\":\"255.255.255.0\",\"$message\":{\"$body\":\"Let’s meet at 5pm\",\"$contact_email\":\"alex_301@domain.com\",\"$root_content_id\":\"listing-123\",\"$recipient_user_ids\":[\"fy9h989sjphh71\"],\"$images\":[{\"$md5_hash\":\"0cc175b9c0f1b6a831c399e269772661\",\"$link\":\"https://www.domain.com/file.png\",\"$description\":\"My hike today!\"},{\"$md5_hash\":\"0cc175b9c0f1b6a831c399e269772661\"}]},\"$browser\":{\"$user_agent\":\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36\",\"$accept_language\":\"en-US\",\"$content_language\":\"en-GB\"},\"$brand_name\":\"sift\",\"$site_country\":\"US\",\"$site_domain\":\"sift.com\"}";
+
+            Assert.Equal(updateListingBody, updateContent.ToJson());
+
+            EventRequest eventRequest = new EventRequest
+            {
+                Event = updateContent
+            };
+
+            Assert.Equal("https://api.sift.com/v205/events", eventRequest.Request.RequestUri.ToString());
+
+            eventRequest = new EventRequest
+            {
+                Event = updateContent,
+                AbuseTypes = { "legacy", "payment_abuse" },
+                ReturnScore = true
+            };
+
+            Assert.Equal("https://api.sift.com/v205/events?abuse_types=legacy,payment_abuse&return_score=true",
+                          Uri.UnescapeDataString(eventRequest.Request.RequestUri.ToString()));
+        }
+
     }
 }

--- a/Test/Test.cs
+++ b/Test/Test.cs
@@ -1702,5 +1702,82 @@ namespace Test
                           Uri.UnescapeDataString(eventRequest.Request.RequestUri.ToString()));
         }
 
+        //UpdateContentProfile
+
+
+        [Fact]
+        public void TestUpdateContentProfile()
+        {
+            var sessionId = "sessionId";
+            var updateContent = new UpdateContent
+            {
+                user_id = "fyw3989sjpqr71",
+                content_id = "listing-23412",
+                session_id = "a234ksjfgn435sfg",
+                status = "$active",
+                ip = "255.255.255.0",
+                profile = new Profile()
+                {
+                    body = "Hi! My name is Alex and I just moved to New London!",
+                    contact_email = "alex_301@domain.com",
+                    contact_address = new Address()
+                    {
+                        name = "Alex Smith",
+                        address_1 = "abc",
+                        address_2 = "xyz",
+                        city = "New London",
+                        region = "New Hampshire",
+                        country = "US",
+                        zipcode = "03257",
+                        phone = "1-415-555-6041"
+                    },
+                    images = new ObservableCollection<Image>()
+                    {
+                        new Image()
+                        {
+                            md5_hash = "0cc175b9c0f1b6a831c399e269772661",
+                            link = "https://www.domain.com/file.png",
+                            description = "Alex’s picture"
+                        },
+                        new Image()
+                        {
+                            md5_hash = "0cc175b9c0f1b6a831c399e269772661"
+                        }
+                    },
+                    categories = new ObservableCollection<string>() { "Friends", "Long-term dating" }
+                },
+                browser = new Browser
+                {
+                    user_agent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36",
+                    accept_language = "en-US",
+                    content_language = "en-GB"
+                },
+                brand_name = "sift",
+                site_country = "US",
+                site_domain = "sift.com",
+            };
+
+            string updateProfileBody = "{\"$type\":\"$update_content\",\"$user_id\":\"fyw3989sjpqr71\",\"$content_id\":\"listing-23412\",\"$session_id\":\"a234ksjfgn435sfg\",\"$status\":\"$active\",\"$ip\":\"255.255.255.0\",\"$profile\":{\"$body\":\"Hi! My name is Alex and I just moved to New London!\",\"$contact_email\":\"alex_301@domain.com\",\"$contact_address\":{\"$name\":\"Alex Smith\",\"$address_1\":\"abc\",\"$address_2\":\"xyz\",\"$city\":\"New London\",\"$region\":\"New Hampshire\",\"$country\":\"US\",\"$zipcode\":\"03257\",\"$phone\":\"1-415-555-6041\"},\"$images\":[{\"$md5_hash\":\"0cc175b9c0f1b6a831c399e269772661\",\"$link\":\"https://www.domain.com/file.png\",\"$description\":\"Alex’s picture\"},{\"$md5_hash\":\"0cc175b9c0f1b6a831c399e269772661\"}],\"$categories\":[\"Friends\",\"Long-term dating\"]},\"$browser\":{\"$user_agent\":\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36\",\"$accept_language\":\"en-US\",\"$content_language\":\"en-GB\"},\"$brand_name\":\"sift\",\"$site_country\":\"US\",\"$site_domain\":\"sift.com\"}";
+
+            Assert.Equal(updateProfileBody, updateContent.ToJson());
+
+            EventRequest eventRequest = new EventRequest
+            {
+                Event = updateContent
+            };
+
+            Assert.Equal("https://api.sift.com/v205/events", eventRequest.Request.RequestUri.ToString());
+
+            eventRequest = new EventRequest
+            {
+                Event = updateContent,
+                AbuseTypes = { "legacy", "payment_abuse" },
+                ReturnScore = true
+            };
+
+            Assert.Equal("https://api.sift.com/v205/events?abuse_types=legacy,payment_abuse&return_score=true",
+                          Uri.UnescapeDataString(eventRequest.Request.RequestUri.ToString()));
+        }
+
     }
 }

--- a/Test/Test.cs
+++ b/Test/Test.cs
@@ -1344,5 +1344,73 @@ namespace Test
             Assert.Equal("https://api.sift.com/v205/events?abuse_types=legacy,payment_abuse&fields=SCORE_PERCENTILES&return_score=true",
                           Uri.UnescapeDataString(eventRequest.Request.RequestUri.ToString()));
         }
+
+
+        //UpdateContentComment
+
+
+        [Fact]
+        public void TestUpdateContentCommentEvent()
+        {
+            var sessionId = "sessionId";
+            var updateContent = new UpdateContentComment
+            {
+                user_id = "fyw3989sjpqr71",
+                content_id = "comment-23412",
+                session_id = "a234ksjfgn435sfg",
+                status = "$active",
+                ip = "255.255.255.0",
+                browser = new Browser
+                {
+                    user_agent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36",
+                    accept_language = "en-US",
+                    content_language = "en-GB"
+                },
+                comment = new Comment()
+                {
+                    body = "Congrats on the new role!",
+                    contact_email = "alex_301@domain.com",
+                    parent_comment_id = "comment-23407",
+                    root_content_id = "listing-12923213",
+                    images = new ObservableCollection<Image>()
+                    {
+                        new Image()
+                        {
+                            md5_hash = "0cc175b9c0f1b6a831c399e269772661",
+                            link = "https://www.example.com/file.png",
+                            description =   "Example picture"
+                        },
+                        new Image()
+                        {
+                            md5_hash = "0cc175b9c0f1b6a831c399e269772661"
+                        }
+                    }
+                },
+                brand_name = "sift",
+                site_country = "US",
+                site_domain = "sift.com",
+            };
+
+            Assert.Equal("{\"$type\":\"$verification\",\"$user_id\":\"billy_jones_301\",\"$session_id\":\"sessionId\",\"$status\":\"$pending\",\"$browser\":{\"$user_agent\":\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36\",\"$accept_language\":\"en-GB\",\"$content_language\":\"en-US\"},\"$verified_event\":\"$login\",\"$verified_entity_id\":\"123\",\"$verification_type\":\"$sms\",\"$verified_value\":\"14155551212\",\"$reason\":\"$user_setting\",\"$brand_name\":\"xyz\",\"$site_country\":\"AU\",\"$site_domain\":\"somehost.example.com\"}",
+                                 verification.ToJson());
+
+            EventRequest eventRequest = new EventRequest
+            {
+                Event = UpdateContentComment
+            };
+
+            Assert.Equal("https://api.sift.com/v205/events", eventRequest.Request.RequestUri.ToString());
+
+            eventRequest = new EventRequest
+            {
+                Event = UpdateContentComment,
+                AbuseTypes = { "legacy", "payment_abuse" },
+                ReturnScore = true
+            };
+
+            Assert.Equal("https://api.sift.com/v205/events?abuse_types=legacy,payment_abuse&return_score=true",
+                          Uri.UnescapeDataString(eventRequest.Request.RequestUri.ToString()));
+        }
+
     }
 }

--- a/Test/Test.cs
+++ b/Test/Test.cs
@@ -8,6 +8,11 @@ using System.Security.Cryptography;
 using System.IO;
 using Sift.Core;
 using System.Linq;
+using System.Reflection;
+using System.Security.Cryptography.X509Certificates;
+using System.Reflection.Emit;
+using System.Numerics;
+using System.Drawing;
 
 namespace Test
 {
@@ -1352,7 +1357,7 @@ namespace Test
         public void TestUpdateContentComment()
         {
             var sessionId = "sessionId";
-            var updateContent= new UpdateContent
+            var updateContent = new UpdateContent
             {
                 user_id = "fyw3989sjpqr71",
                 content_id = "comment-23412",
@@ -1412,5 +1417,123 @@ namespace Test
                           Uri.UnescapeDataString(eventRequest.Request.RequestUri.ToString()));
         }
 
+        //UpdateContentListing
+
+
+        [Fact]
+        public void TestUpdateContentListing()
+        {
+            var sessionId = "sessionId";
+            var updateContent = new UpdateContent
+            {
+                user_id = "fyw3989sjpqr71",
+                content_id = "listing-23412",
+                session_id = "a234ksjfgn435sfg",
+                status = "$active",
+                ip = "255.255.255.0",
+                browser = new Browser
+                {
+                    user_agent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36",
+                    accept_language = "en-US",
+                    content_language = "en-GB"
+                },
+                listing = new Listing()
+                {
+                    subject = "2 Bedroom Apartment for Rent",
+                    body = "Capitol Hill Seattle brand new condo. 2 bedrooms and 1 full bath.",
+                    contact_email = "alex_301@domain.com",
+                    contact_address = new Address()
+                    {
+                        name = "Bill Jones",
+                        address_1 = "abc",
+                        address_2 = "xyz",
+                        city = "New London",
+                        region = "New Hampshire",
+                        country = "US",
+                        zipcode = "03257",
+                        phone = "1-415-555-6041"
+
+
+                    },
+                    locations = new ObservableCollection<Address>()
+                    {
+                        new Address()
+                        {
+                            name = "Bill Jones",
+                            address_1 = "abc",
+                            address_2 = "xyz",
+                            city = "Seattle",
+                            region = "Washington",
+                            country = "US",
+                            zipcode = "98112",
+                            phone = "1-415-555-6041"
+                        },
+                        new Address()
+                        {
+                            name = "Bill Jones"
+                        }
+
+                    },
+                    listed_items = new ObservableCollection<Item>()
+                    {
+                        new Item()
+                        {
+                            item_id = "0cc175b9c0f1b6a831c399e269772661",
+                            product_title = "https://www.domain.com/file.png",
+                            price = 2950000000,
+                            currency_code = "USD",
+                            quantity = 1,
+                            upc = "6786211451001",
+                            sku = "abc",
+                            isbn = "0446576220",
+                            brand = "abc",
+                            manufacturer = "abc",
+                            category = "abc",
+                            tags = new ObservableCollection<string>() { "heat","washer/dryer" },
+                            color = "ab",
+                            size = "ab"
+                        }
+                    },
+                    images = new ObservableCollection<Image>()
+                    {
+                        new Image()
+                        {
+                            md5_hash = "0cc175b9c0f1b6a831c399e269772661",
+                            link = "https://www.domain.com/file.png",
+                            description =   "Billy's picture"
+                        },
+                        new Image()
+                        {
+                            md5_hash = "0cc175b9c0f1b6a831c399e269772661"
+                        }
+                    },
+                    expiration_time = 1549063157000
+                },
+                brand_name = "sift",
+                site_country = "US",
+                site_domain = "sift.com",
+            };
+
+            string updateListingBody = "{\"$type\":\"$update_content\",\"$user_id\":\"fyw3989sjpqr71\",\"$content_id\":\"listing-23412\",\"$session_id\":\"a234ksjfgn435sfg\",\"$status\":\"$active\",\"$ip\":\"255.255.255.0\",\"$listing\":{\"$subject\":\"2 Bedroom Apartment for Rent\",\"$body\":\"Capitol Hill Seattle brand new condo. 2 bedrooms and 1 full bath.\",\"$contact_email\":\"alex_301@domain.com\",\"$contact_address\":{\"$name\":\"Bill Jones\",\"$address_1\":\"abc\",\"$address_2\":\"xyz\",\"$city\":\"New London\",\"$region\":\"New Hampshire\",\"$country\":\"US\",\"$zipcode\":\"03257\",\"$phone\":\"1-415-555-6041\"},\"$locations\":[{\"$name\":\"Bill Jones\",\"$address_1\":\"abc\",\"$address_2\":\"xyz\",\"$city\":\"Seattle\",\"$region\":\"Washington\",\"$country\":\"US\",\"$zipcode\":\"98112\",\"$phone\":\"1-415-555-6041\"},{\"$name\":\"Bill Jones\"}],\"$listed_items\":[{\"$item_id\":\"0cc175b9c0f1b6a831c399e269772661\",\"$product_title\":\"https://www.domain.com/file.png\",\"$price\":2950000000,\"$currency_code\":\"USD\",\"$quantity\":1,\"$upc\":\"6786211451001\",\"$sku\":\"abc\",\"$isbn\":\"0446576220\",\"$brand\":\"abc\",\"$manufacturer\":\"abc\",\"$category\":\"abc\",\"$tags\":[\"heat\",\"washer/dryer\"],\"$color\":\"ab\",\"$size\":\"ab\"}],\"$images\":[{\"$md5_hash\":\"0cc175b9c0f1b6a831c399e269772661\",\"$link\":\"https://www.domain.com/file.png\",\"$description\":\"Billy's picture\"},{\"$md5_hash\":\"0cc175b9c0f1b6a831c399e269772661\"}],\"$expiration_time\":1549063157000},\"$browser\":{\"$user_agent\":\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36\",\"$accept_language\":\"en-US\",\"$content_language\":\"en-GB\"},\"$brand_name\":\"sift\",\"$site_country\":\"US\",\"$site_domain\":\"sift.com\"}";
+
+            Assert.Equal(updateListingBody, updateContent.ToJson());
+
+            EventRequest eventRequest = new EventRequest
+            {
+                Event = updateContent
+            };
+
+            Assert.Equal("https://api.sift.com/v205/events", eventRequest.Request.RequestUri.ToString());
+
+            eventRequest = new EventRequest
+            {
+                Event = updateContent,
+                AbuseTypes = { "legacy", "payment_abuse" },
+                ReturnScore = true
+            };
+
+            Assert.Equal("https://api.sift.com/v205/events?abuse_types=legacy,payment_abuse&return_score=true",
+                          Uri.UnescapeDataString(eventRequest.Request.RequestUri.ToString()));
+        }
     }
 }

--- a/Test/Test.cs
+++ b/Test/Test.cs
@@ -1345,7 +1345,6 @@ namespace Test
                           Uri.UnescapeDataString(eventRequest.Request.RequestUri.ToString()));
         }
 
-
         //UpdateContentComment
 
 

--- a/Test/Test.cs
+++ b/Test/Test.cs
@@ -1779,7 +1779,9 @@ namespace Test
                           Uri.UnescapeDataString(eventRequest.Request.RequestUri.ToString()));
         }
 
-        //UpdateContentReview
+        /// <summary>
+        /// Unit test for UpdateContent.Review
+        /// </summary>
         [Fact]
         public void TestUpdateContentReview()
         {

--- a/Test/Test.cs
+++ b/Test/Test.cs
@@ -1550,13 +1550,13 @@ namespace Test
                 content_id = "message-23412",
                 session_id = "a234ksjfgn435sfg",
                 status = "$active",
-                ip = "255.255.255.0",                
+                ip = "255.255.255.0",
                 message = new Message()
                 {
                     body = "Let’s meet at 5pm",
                     contact_email = "alex_301@domain.com",
                     root_content_id = "listing-123",
-                    recipient_user_ids = new ObservableCollection<string>() { "fy9h989sjphh71"},
+                    recipient_user_ids = new ObservableCollection<string>() { "fy9h989sjphh71" },
                     images = new ObservableCollection<Image>()
                     {
                         new Image()
@@ -1760,6 +1760,108 @@ namespace Test
             string updateProfileBody = "{\"$type\":\"$update_content\",\"$user_id\":\"fyw3989sjpqr71\",\"$content_id\":\"listing-23412\",\"$session_id\":\"a234ksjfgn435sfg\",\"$status\":\"$active\",\"$ip\":\"255.255.255.0\",\"$profile\":{\"$body\":\"Hi! My name is Alex and I just moved to New London!\",\"$contact_email\":\"alex_301@domain.com\",\"$contact_address\":{\"$name\":\"Alex Smith\",\"$address_1\":\"abc\",\"$address_2\":\"xyz\",\"$city\":\"New London\",\"$region\":\"New Hampshire\",\"$country\":\"US\",\"$zipcode\":\"03257\",\"$phone\":\"1-415-555-6041\"},\"$images\":[{\"$md5_hash\":\"0cc175b9c0f1b6a831c399e269772661\",\"$link\":\"https://www.domain.com/file.png\",\"$description\":\"Alex’s picture\"},{\"$md5_hash\":\"0cc175b9c0f1b6a831c399e269772661\"}],\"$categories\":[\"Friends\",\"Long-term dating\"]},\"$browser\":{\"$user_agent\":\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36\",\"$accept_language\":\"en-US\",\"$content_language\":\"en-GB\"},\"$brand_name\":\"sift\",\"$site_country\":\"US\",\"$site_domain\":\"sift.com\"}";
 
             Assert.Equal(updateProfileBody, updateContent.ToJson());
+
+            EventRequest eventRequest = new EventRequest
+            {
+                Event = updateContent
+            };
+
+            Assert.Equal("https://api.sift.com/v205/events", eventRequest.Request.RequestUri.ToString());
+
+            eventRequest = new EventRequest
+            {
+                Event = updateContent,
+                AbuseTypes = { "legacy", "payment_abuse" },
+                ReturnScore = true
+            };
+
+            Assert.Equal("https://api.sift.com/v205/events?abuse_types=legacy,payment_abuse&return_score=true",
+                          Uri.UnescapeDataString(eventRequest.Request.RequestUri.ToString()));
+        }
+
+        //UpdateContentReview
+        [Fact]
+        public void TestUpdateContentReview()
+        {
+            var sessionId = "sessionId";
+            var updateContent = new UpdateContent
+            {
+                user_id = "fyw3989sjpqr71",
+                content_id = "review-23412",
+                session_id = "a234ksjfgn435sfg",
+                status = "$active",
+                ip = "255.255.255.0",
+                review = new Review()
+                {
+                    subject = "Amazing Tacos!",
+                    body = "I ate the tacos.",
+                    contact_email = "alex_301@domain.com",
+                    locations = new ObservableCollection<Address>()
+                    {
+                        new Address()
+                        {
+                            name = "Bill Jones",
+                            address_1 = "abc",
+                            address_2 = "xyz",
+                            city = "Seattle",
+                            region = "Washington",
+                            country = "US",
+                            zipcode = "98112",
+                            phone = "1-415-555-6041"
+                        },
+                        new Address()
+                        {
+                            name = "Bill Jones"
+                        }
+
+                    },
+                    item_reviewed = new Item()
+                    {
+                        item_id = "B004834GQO",
+                        product_title = "The Slanket Blanket-Texas Tea",
+                        price = 39990000,
+                        currency_code = "USD",
+                        upc = "6786211451001",
+                        sku = "004834GQ",
+                        isbn = "0446576220",
+                        brand = "Slanket",
+                        manufacturer = "Slanket",
+                        category = "Blankets & Throws",
+                        tags = new ObservableCollection<string>() { "Awesome", "Wintertime specials" },
+                        color = "Texas Tea",
+                        size = "6",
+                    },
+
+                    reviewed_content_id = "listing-234234",
+                    rating = 4.5,
+                    images = new ObservableCollection<Image>()
+                    {
+                        new Image()
+                        {
+                            md5_hash = "0cc175b9c0f1b6a831c399e269772661",
+                            link = "https://www.domain.com/file.png",
+                            description = "Calamari tacos."
+                        },
+                        new Image()
+                        {
+                            md5_hash = "0cc175b9c0f1b6a831c399e269772661"
+                        }
+                    },
+                },
+                browser = new Browser
+                {
+                    user_agent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36",
+                    accept_language = "en-US",
+                    content_language = "en-GB"
+                },
+                brand_name = "sift",
+                site_country = "US",
+                site_domain = "sift.com",
+            };
+
+            string updateReviewBody = "{\"$type\":\"$update_content\",\"$user_id\":\"fyw3989sjpqr71\",\"$content_id\":\"review-23412\",\"$session_id\":\"a234ksjfgn435sfg\",\"$status\":\"$active\",\"$ip\":\"255.255.255.0\",\"$review\":{\"$subject\":\"Amazing Tacos!\",\"$body\":\"I ate the tacos.\",\"$contact_email\":\"alex_301@domain.com\",\"$locations\":[{\"$name\":\"Bill Jones\",\"$address_1\":\"abc\",\"$address_2\":\"xyz\",\"$city\":\"Seattle\",\"$region\":\"Washington\",\"$country\":\"US\",\"$zipcode\":\"98112\",\"$phone\":\"1-415-555-6041\"},{\"$name\":\"Bill Jones\"}],\"$item_reviewed\":{\"$item_id\":\"B004834GQO\",\"$product_title\":\"The Slanket Blanket-Texas Tea\",\"$price\":39990000,\"$currency_code\":\"USD\",\"$upc\":\"6786211451001\",\"$sku\":\"004834GQ\",\"$isbn\":\"0446576220\",\"$brand\":\"Slanket\",\"$manufacturer\":\"Slanket\",\"$category\":\"Blankets & Throws\",\"$tags\":[\"Awesome\",\"Wintertime specials\"],\"$color\":\"Texas Tea\",\"$size\":\"6\"},\"$reviewed_content_id\":\"listing-234234\",\"$rating\":4.5,\"$images\":[{\"$md5_hash\":\"0cc175b9c0f1b6a831c399e269772661\",\"$link\":\"https://www.domain.com/file.png\",\"$description\":\"Calamari tacos.\"},{\"$md5_hash\":\"0cc175b9c0f1b6a831c399e269772661\"}]},\"$browser\":{\"$user_agent\":\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36\",\"$accept_language\":\"en-US\",\"$content_language\":\"en-GB\"},\"$brand_name\":\"sift\",\"$site_country\":\"US\",\"$site_domain\":\"sift.com\"}";
+
+            Assert.Equal(updateReviewBody, updateContent.ToJson());
 
             EventRequest eventRequest = new EventRequest
             {


### PR DESCRIPTION
## Purpose
Add $update_content event type
## Summary
Add $update_content event type, which contain 6 types of update:

1. $update_content.comment
2. $update_content.listing
3. $update_content.message
4. $update_content.post
5. $update_content.profile
6. $update_content.review

## Testing
Six unit tests were created for each and every update also done the integration tests for the same, but those are not committed due to sensitive information.

## Checklist
- [x] The change was thoroughly tested manually
- [x] The change was covered with unit tests
- [x] The change was tested with real API calls (if applicable)
- [x] Necessary changes were made in the integration tests (if applicable)
- [x] New functionality is reflected in README
