### PR TITLE
Implemented missing fields from Verification API

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,3 +215,73 @@ The official Sift .NET client, supporting .NET Standard 2.0+
     {
         // Handle InnerException
     }
+
+### Verification
+
+    // send
+    try
+            {
+                VerificationSendResponse res = sift.SendAsync(new VerificationSendRequest
+                    {
+                        UserId = "USER_ID",
+                        BrandName = "MyTopBrand",
+                        VerificationType = "$email",
+                        SendTo = "SEND_TO",
+                        Language = "en",
+                        SiteCountry = "IN",
+                        Event = new VerificationSendEvent()
+                        {
+                            Browser = new Browser()
+                            {
+                                user_agent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36",
+                                content_language = "en-US",
+                                accept_language = "en-GB",
+                            },
+                            IP = "192.168.1.1",
+                            Reason = "$automated_rule",
+                            SessionId = "SOME_SESSION_ID",
+                            VerifiedEvent = "$login",
+                            VerifiedEntityId = "SOME_SESSION_ID",
+                        }
+                    }
+                ).Result;
+            }
+            catch (AggregateException ae)
+            {
+                // Handle InnerException
+            }
+
+    // resend
+        try
+            {
+                VerificationReSendResponse res = sift.SendAsync(new VerificationReSendRequest
+                    {
+                        UserId = "USER_ID",
+                        VerifiedEntityId = "SOME_SESSION_ID",
+                        VerifiedEvent = "$login"
+
+                    }
+                ).Result;
+            }
+            catch (AggregateException ae)
+            {
+                // Handle InnerException
+            }
+
+    // check
+         try
+            {
+                VerificationCheckResponse res = sift.SendAsync(new VerificationCheckRequest
+                    {
+                        Code = 147222,
+                        UserId = "USER_ID",
+                        VerifiedEvent = "$login",
+                        VerifiedEntityId = "SOME_SESSION_ID"
+
+                    }
+                ).Result;
+            }
+            catch (AggregateException ae)
+            {
+                // Handle InnerException
+            }

--- a/Sift/Request/VerificationRequest.cs
+++ b/Sift/Request/VerificationRequest.cs
@@ -1,6 +1,5 @@
 ﻿using Newtonsoft.Json;
 using System;
-using System.Collections.Generic;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
@@ -9,7 +8,7 @@ namespace Sift
 {
     public class VerificationCheckRequest : SiftRequest
     {
-        static readonly String VerificationCheckUrl = @"https://api.sift.com/v1.1/verification/check";
+        static readonly String VerificationCheckUrl = @"https://api.sift.com/v1/verification/check";
 
         [JsonIgnore]
         public override string ApiKey { get; set; }
@@ -50,14 +49,13 @@ namespace Sift
 
     public class VerificationSendRequest : SiftRequest
     {
-        static readonly String VerificationSendUrl = @"https://api.sift.com/v1.1/verification/send";
+        static readonly String VerificationSendUrl = @"https://api.sift.com/v1/verification/send";
 
         [JsonIgnore]
         public override string ApiKey { get; set; }
 
         [JsonProperty("$user_id", NullValueHandling = NullValueHandling.Ignore)]
         public string UserId { get; set; }
-
 
         [JsonProperty("$send_to", NullValueHandling = NullValueHandling.Ignore)]
         public string SendTo { get; set; }
@@ -67,6 +65,9 @@ namespace Sift
 
         [JsonProperty("$brand_name", NullValueHandling = NullValueHandling.Ignore)]
         public string BrandName { get; set; }
+
+        [JsonProperty("$site_country", NullValueHandling = NullValueHandling.Ignore)]
+        public string SiteCountry { get; set; }
 
         [JsonProperty("$language", NullValueHandling = NullValueHandling.Ignore)]
         public string Language { get; set; }
@@ -98,7 +99,7 @@ namespace Sift
 
     public class VerificationReSendRequest : SiftRequest
     {
-        static readonly String VerificationReSendUrl = @"https://api.sift.com/v1.1/verification/resend";
+        static readonly String VerificationReSendUrl = @"https://api.sift.com/v1/verification/resend";
 
         [JsonIgnore]
         public override string ApiKey { get; set; }
@@ -134,7 +135,6 @@ namespace Sift
         }
     }
 
-
     public class VerificationSendEvent
     {
         [JsonProperty("$session_id", NullValueHandling = NullValueHandling.Ignore)]
@@ -143,19 +143,19 @@ namespace Sift
         [JsonProperty("$verified_event", NullValueHandling = NullValueHandling.Ignore)]
         public string VerifiedEvent { get; set; }
 
+        [JsonProperty("$verified_entity_id", NullValueHandling = NullValueHandling.Ignore)]
+        public string VerifiedEntityId { get; set; }
+
         [JsonProperty("$reason", NullValueHandling = NullValueHandling.Ignore)]
         public string Reason { get; set; }
 
         [JsonProperty("$ip", NullValueHandling = NullValueHandling.Ignore)]
         public string IP { get; set; }
 
-        [JsonProperty("$browser")]
-        public VerificationSendBrowser Browser { get; set; }
-    }
+        [Newtonsoft.Json.JsonProperty("$browser", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public Browser Browser { get; set; }
 
-    public class VerificationSendBrowser
-    {
-        [JsonProperty("$user_agent", NullValueHandling = NullValueHandling.Ignore)]
-        public string UserAgent { get; set; }
+        [Newtonsoft.Json.JsonProperty("$app", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public App App { get; set; }
     }
 }

--- a/Test/Test.cs
+++ b/Test/Test.cs
@@ -819,7 +819,7 @@ namespace Test
                 verificationCheckRequest.Request.Headers.Authorization!.Parameter);
 
             Assert.Equal("https://api.sift.com/v1/verification/check",
-                         verificationCheckRequest.Request.RequestUri.ToString());
+                         verificationCheckRequest.Request.RequestUri!.ToString());
         }
 
         [Fact]
@@ -860,7 +860,7 @@ namespace Test
                 verificationSendRequest.Request.Headers.Authorization!.Parameter);
 
             Assert.Equal("https://api.sift.com/v1/verification/send",
-                         verificationSendRequest.Request.RequestUri.ToString());
+                         verificationSendRequest.Request.RequestUri!.ToString());
         }
 
         [Fact]
@@ -881,7 +881,7 @@ namespace Test
                 verificationResendRequest.Request.Headers.Authorization!.Parameter);
 
             Assert.Equal("https://api.sift.com/v1/verification/resend",
-                         verificationResendRequest.Request.RequestUri.ToString());
+                         verificationResendRequest.Request.RequestUri!.ToString());
         }
 
 

--- a/Test/Test.cs
+++ b/Test/Test.cs
@@ -8,6 +8,7 @@ using System.Security.Cryptography;
 using System.IO;
 using Sift.Core;
 using System.Linq;
+using Newtonsoft.Json;
 
 namespace Test
 {
@@ -808,8 +809,9 @@ namespace Test
 
                 ApiKey = apiKey,
                 Code = 655543,
-                UserId = "vineethk@exalture.com"
-
+                UserId = "haneeshv@exalture.com",
+                VerifiedEntityId = "SOME_SESSION_ID",
+                VerifiedEvent = "$login"
             };
 
             verificationCheckRequest.ApiKey = apiKey;
@@ -817,7 +819,7 @@ namespace Test
             Assert.Equal(Convert.ToBase64String(Encoding.Default.GetBytes(apiKey)),
                 verificationCheckRequest.Request.Headers.Authorization.Parameter);
 
-            Assert.Equal("https://api.sift.com/v1.1/verification/check",
+            Assert.Equal("https://api.sift.com/v1/verification/check",
                          verificationCheckRequest.Request.RequestUri.ToString());
         }
 
@@ -830,22 +832,26 @@ namespace Test
             var sessionId = "sessionId";
             var verificationSendRequest = new VerificationSendRequest
             {
-                UserId = "vineethk@exalture.com",
+                UserId = "haneeshv@exalture.com",
                 ApiKey = apiKey,
                 BrandName = "all",
                 VerificationType = "$email",
-                SendTo = "vineethk@exalture.com",
+                SendTo = "haneeshv@exalture.com",
                 Language = "en",
+                SiteCountry = "IN",
                 Event = new VerificationSendEvent()
                 {
-                    Browser = new VerificationSendBrowser()
+                    Browser = new Browser()
                     {
-                        UserAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36"
+                        user_agent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36",
+                        content_language = "en-US",
+                        accept_language = "en-GB",
                     },
                     IP = "192.168.1.1",
                     Reason = "$automated_rule",
                     SessionId = sessionId,
-                    VerifiedEvent = "$login"
+                    VerifiedEvent = "$login",
+                    VerifiedEntityId = "SOME_SESSION_ID"
                 }
             };
 
@@ -854,7 +860,7 @@ namespace Test
             Assert.Equal(Convert.ToBase64String(Encoding.Default.GetBytes(apiKey)),
                 verificationSendRequest.Request.Headers.Authorization.Parameter);
 
-            Assert.Equal("https://api.sift.com/v1.1/verification/send",
+            Assert.Equal("https://api.sift.com/v1/verification/send",
                          verificationSendRequest.Request.RequestUri.ToString());
         }
 
@@ -865,18 +871,17 @@ namespace Test
             var apiKey = "key";
             var verificationResendRequest = new VerificationReSendRequest
             {
-                UserId = "vineethk@exalture.com",
-                ApiKey = apiKey
-
-
+                UserId = "haneeshv@exalture.com",
+                ApiKey = apiKey,
+                VerifiedEntityId = "SOME_SESSION_ID",
+                VerifiedEvent = "$login"
             };
             verificationResendRequest.ApiKey = apiKey;
 
             Assert.Equal(Convert.ToBase64String(Encoding.Default.GetBytes(apiKey)),
                 verificationResendRequest.Request.Headers.Authorization.Parameter);
 
-
-            Assert.Equal("https://api.sift.com/v1.1/verification/resend",
+            Assert.Equal("https://api.sift.com/v1/verification/resend",
                          verificationResendRequest.Request.RequestUri.ToString());
         }
 


### PR DESCRIPTION
## Purpose
As a result of the audit we spotted some discrepancies need to be addressed

## Summary
For Verification API /send request there are some missing fields in the library:

- verified_entity_id

- site_country

- event.$app + internal structures

- event.$browser.$content_language

## Testing
Missing fields are added and thoroughly tested
## Checklist
- [X] The change was thoroughly tested manually
- [X] The change was covered with unit tests
- [X] The change was tested with real API calls (if applicable)
- [X] Necessary changes were made in the integration tests (if applicable)
- [X] New functionality is reflected in README
