### PR TITLE
Add warnings to Event Response

### DIFF
--- a/Sift/Request/EventRequest.cs
+++ b/Sift/Request/EventRequest.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net.Http;
+using System.Reflection;
 using System.Text;
 
 namespace Sift
@@ -11,11 +13,13 @@ namespace Sift
 
         public SiftEvent Event { get; set; }
         public List<String> AbuseTypes { get; set; } = new List<string>();
+        public List<String> fields { get; set; } = new List<string>();
         public bool IncludeScorePercentile { get; set; }
         public bool ReturnScore { get; set; }
         public bool ReturnWorkflowStatus { get; set; }
         public bool ReturnRouteInfo { get; set; }
         public bool ForceWorkflowRun { get; set; }
+        public bool ReturnWarnings { get; set; }
 
         public override HttpRequestMessage Request
         {
@@ -41,7 +45,7 @@ namespace Sift
                 
                 if (IncludeScorePercentile)
                 {
-                    url = url.AddQuery("fields", "SCORE_PERCENTILES");
+                    fields.Add("SCORE_PERCENTILES");
                 }
 
                 if (ReturnScore)
@@ -62,6 +66,14 @@ namespace Sift
                 if (ForceWorkflowRun)
                 {
                     url = url.AddQuery("force_workflow_run", "true");
+                }
+                if (ReturnWarnings)
+                {
+                    fields.Add("warnings");
+                }
+                if (fields.Any())
+                {
+                    url = url.AddQuery("fields", string.Join(",", fields));
                 }
 
                 return url;

--- a/Sift/Response/EventResponse.cs
+++ b/Sift/Response/EventResponse.cs
@@ -1,4 +1,6 @@
 ﻿using Newtonsoft.Json;
+using Sift.Response;
+using System.Collections.Generic;
 
 namespace Sift
 {
@@ -6,5 +8,8 @@ namespace Sift
     {
         [JsonProperty("score_response")]
         public ScoreResponse ScoreResponse { get; set; }
+        [JsonProperty("warnings")]
+        public WarningsResponse Warnings { get; set; }
     }
+
 }

--- a/Sift/Response/WarningsResponse.cs
+++ b/Sift/Response/WarningsResponse.cs
@@ -1,0 +1,22 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Sift.Response
+{
+    public class WarningsResponse
+    {
+        [JsonProperty("count")]
+        public int Count { get; set; }
+
+        [JsonProperty("items")]
+        public List<WarningItem> Items { get; set; }
+
+        public class WarningItem
+        {
+            [JsonProperty("message")]
+            public string Message { get; set; }
+        }
+    }
+}

--- a/Test/Test.cs
+++ b/Test/Test.cs
@@ -1340,7 +1340,7 @@ namespace Test
                 ReturnScore = true
             };
 
-            Assert.Equal("https://api.sift.com/v205/events?abuse_types=legacy,payment_abuse&fields=SCORE_PERCENTILES&return_score=true",
+            Assert.Equal("https://api.sift.com/v205/events?abuse_types=legacy,payment_abuse&return_score=true&fields=SCORE_PERCENTILES",
                           Uri.UnescapeDataString(eventRequest.Request.RequestUri!.ToString()));
         }
 

--- a/Test/Test.cs
+++ b/Test/Test.cs
@@ -1,10 +1,12 @@
 using Newtonsoft.Json;
 using Sift;
 using Sift.Core;
+using Sift.Response;
 using System.Collections.ObjectModel;
 using System.Security.Cryptography;
 using System.Text;
 using Xunit;
+using static Sift.Response.WarningsResponse;
 
 namespace Test
 {
@@ -2601,8 +2603,8 @@ namespace Test
             var sessionId = "sessionId";
             var transaction = new Transaction
             {
-                user_id = "vineethk@exalture.com",
-                amount = 1000000000000L,
+                user_id = "haneeshv@exalture.com",
+                amount = 100000L,
                 currency_code = "@#$",
                 session_id = sessionId,
                 transaction_type = "$sale",
@@ -2616,8 +2618,14 @@ namespace Test
                 ReturnWarnings = true
             };
 
+            string responseBody = "{\"status\":53,\"error_message\":\"Invalid field value(s) for fields: $.$amount, $.$currency_code. Please check the documentation for valid field values.\",\"time\":1717399201,\"warnings\":{\"count\":2,\"items\":[{\"message\":\"Invalid field value at $.$amount\"},{\"message\":\"Invalid field value at $.$currency_code\"}]}}";
+
+            EventResponse response = JsonConvert.DeserializeObject<EventResponse>(responseBody);
+
             Assert.Equal("https://api.sift.com/v205/events?fields=warnings",
                           Uri.UnescapeDataString(eventRequest.Request.RequestUri!.ToString()));
+            Assert.Equal(2, response.Warnings.Count);
+
         }
 
     }

--- a/Test/Test.cs
+++ b/Test/Test.cs
@@ -1,12 +1,10 @@
 using Newtonsoft.Json;
 using Sift;
 using Sift.Core;
-using Sift.Response;
 using System.Collections.ObjectModel;
 using System.Security.Cryptography;
 using System.Text;
 using Xunit;
-using static Sift.Response.WarningsResponse;
 
 namespace Test
 {

--- a/Test/Test.cs
+++ b/Test/Test.cs
@@ -1,3 +1,4 @@
+using Newtonsoft.Json;
 using Sift;
 using Sift.Core;
 using System.Collections.ObjectModel;
@@ -2591,7 +2592,34 @@ namespace Test
 
             Assert.Equal("https://api.sift.com/v205/users/123/score?api_key=345&abuse_types=payment_abuse,promotion_abuse&fields=SCORE_PERCENTILES",
                         Uri.UnescapeDataString(scoreRequest.Request.RequestUri!.ToString()));
-        }   
+        }
+
+        //TestWarnings
+        [Fact]
+        public void TestWarnings()
+        {
+            var sessionId = "sessionId";
+            var transaction = new Transaction
+            {
+                user_id = "vineethk@exalture.com",
+                amount = 1000000000000L,
+                currency_code = "@#$",
+                session_id = sessionId,
+                transaction_type = "$sale",
+                transaction_status = "$failure",
+                decline_category = "$invalid"
+            };
+
+            EventRequest eventRequest = new EventRequest
+            {
+                Event = transaction,
+                ReturnWarnings = true
+            };
+
+            Assert.Equal("https://api.sift.com/v205/events?fields=warnings",
+                          Uri.UnescapeDataString(eventRequest.Request.RequestUri!.ToString()));
+        }
+
     }
 
 }


### PR DESCRIPTION
## Purpose
Add warnings support in sift-dotnet
## Summary
Implemented warnings in Events API: if specify fields=warnings in the request we may return the information about warnings
## Testing
Unit tests updated
## Checklist
- [X] The change was thoroughly tested manually
- [X] The change was covered with unit tests
- [X] The change was tested with real API calls (if applicable)
- [X] Necessary changes were made in the integration tests (if applicable)
- [ ] New functionality is reflected in README
