### PR TITLE
adding $iata_carrier_code to the  $booking complex field

### DIFF
--- a/Sift/Schema/ComplexTypes/booking.json
+++ b/Sift/Schema/ComplexTypes/booking.json
@@ -25,6 +25,9 @@
         "$currency_code": {
             "type": [ "string", "null" ]
         },
+        "$iata_carrier_code": {
+            "type": [ "string", "null" ]
+        },
         "$quantity": {
             "type": [ "integer", "null" ]
         },

--- a/Sift/Sift.csproj
+++ b/Sift/Sift.csproj
@@ -4,7 +4,7 @@
     <Authors>Sift</Authors>
     <AssemblyTitle>Sift</AssemblyTitle>
     <AssemblyName>Sift</AssemblyName>
-    <VersionPrefix>1.3.0</VersionPrefix>
+    <VersionPrefix>1.4.0</VersionPrefix>
     <PackageReleaseNotes>Release 1.3.0</PackageReleaseNotes>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>Sift</PackageId>

--- a/Test/Test.cs
+++ b/Test/Test.cs
@@ -55,6 +55,7 @@ namespace Test
                         end_time= 2038412903,
                         price = 49900000,
                         currency_code = "USD",
+                        iata_carrier_code = "AS", 
                         quantity = 1,
                         venue_id = "venue-123",
                         event_id = "event-123",
@@ -161,7 +162,7 @@ namespace Test
                          "\"$session_id\":\"sessionId\",\"$order_id\":\"oid\",\"$user_email\":\"bill@gmail.com\"," +
                          "\"$amount\":1000000000000,\"$currency_code\":\"USD\",\"$billing_address\":{\"$name\":\"gary\",\"$city\":\"san francisco\"}," +
                          "\"$bookings\":[{\"$booking_type\":\"$flight\",\"$title\":\"SFO - LAS, 2 Adults\",\"$start_time\":2038412903," +
-                         "\"$end_time\":2038412903,\"$price\":49900000,\"$currency_code\":\"USD\",\"$quantity\":1,\"$guests\":[{\"$name\":\"John Doe\"," +
+                         "\"$end_time\":2038412903,\"$price\":49900000,\"$currency_code\":\"USD\",\"$iata_carrier_code\":\"AS\",\"$quantity\":1,\"$guests\":[{\"$name\":\"John Doe\"," +
                          "\"$email\":\"jdoe@domain.com\",\"$phone\":\"1-415-555-6040\",\"$loyalty_program\":\"skymiles\",\"$loyalty_program_id\":\"PSOV34DF\"," +
                          "\"$birth_date\":\"1985-01-19\"},{\"$name\":\"John Doe\"}],\"$segments\":[{\"$start_time\":203841290300,\"$end_time\":2038412903," +
                          "\"$vessel_number\":\"LH454\",\"$departure_airport_code\":\"SFO\",\"$arrival_airport_code\":\"LAS\",\"$fare_class\":\"Premium Economy\"," +


### PR DESCRIPTION
## Purpose
Adding support for $iata_carrier_code field for $booking complex field
## Summary
Adding support for $iata_carrier_code field for $booking complex field to support new use-cases
## Testing
- Updated unit tests
## Checklist
- [x] The change was thoroughly tested manually
- [x] The change was covered with unit tests
- [ ] The change was tested with real API calls (if applicable)
- [ ] Necessary changes were made in the integration tests (if applicable)
- [ ] New functionality is reflected in README
