### PR TITLE
PAY-5294 - iGaming Events API

### DIFF
--- a/README.md
+++ b/README.md
@@ -672,6 +672,122 @@ The official Sift .NET client, supporting .NET Standard 2.0+
         // Handle InnerException
     }
 
+    // Construct reserved events with known fields Transaction
+    var transaction = new Transaction
+        {
+            "$user_id"          : "billy_jones_301",
+            "$amount"           : 506790000, 
+            "$currency_code"    : "USD",
+            "$user_email"                : "billjones1@example.com",
+            "$verification_phone_number" : "+123456789012",
+            "$transaction_type"          : "$sale",
+            "$transaction_status"        : "$failure",
+            "$decline_category"          : "$bank_decline",
+            "$order_id"                  : "ORDER-123124124",
+            "$transaction_id"            : "719637215",
+            "$ip"                        : "54.208.214.78",
+            "$billing_address"  : { 
+                "$name"         : "Bill Jones",
+                "$phone"        : "1-415-555-6041",
+                "$address_1"    : "2100 Main Street",
+                "$address_2"    : "Apt 3B",
+                "$city"         : "New London",
+                "$region"       : "New Hampshire",
+                "$country"      : "US",
+                "$zipcode"      : "03257"
+            },
+            "$brand_name"   : "sift",
+            "$site_domain"  : "sift.com",
+            "$site_country" : "US",
+            "$ordered_from" : {
+                "$store_id"      : "123",
+                "$store_address" : {
+                "$name"       : "Bill Jones",
+                "$phone"      : "1-415-555-6040",
+                "$address_1"  : "2100 Main Street",
+                "$address_2"  : "Apt 3B",
+                "$city"       : "New London",
+                "$region"     : "New Hampshire",
+                "$country"    : "US",
+                "$zipcode"    : "03257"
+                }
+            },
+            "$payment_method"   : {
+                "$payment_type"    : "$credit_card",
+                "$payment_gateway" : "$braintree",
+                "$card_bin"        : "542486",
+                "$card_last4"      : "4444"
+            },
+            "$status_3ds"                     : "$attempted",
+            "$triggered_3ds"                  : "$processor",
+            "$merchant_initiated_transaction" : false,
+            "$shipping_address" : {
+                "$name"         : "Bill Jones",
+                "$phone"        : "1-415-555-6041",
+                "$address_1"    : "2100 Main Street",
+                "$address_2"    : "Apt 3B",
+                "$city"         : "New London",
+                "$region"       : "New Hampshire",
+                "$country"      : "US",
+                "$zipcode"      : "03257"
+            },
+            "$session_id"       : "gigtleqddo84l8cm15qe4il",
+            "$seller_user_id"     : "slinkys_emporium",
+            "digital_wallet"      : "apple_pay", 
+            "coupon_code"         : "dollarMadness",
+            "shipping_choice"     : "FedEx Ground Courier",
+            "is_first_time_buyer" : false,
+            "$browser"        : {
+                "$user_agent"       : "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36",
+                "$accept_language"  : "en-US",
+                "$content_language" : "en-GB"
+            }
+        };
+
+    EventRequest eventRequest = new EventRequest()
+    {
+        Event = transaction
+    };
+    try
+    {
+        EventResponse res = sift.SendAsync(eventRequest).Result;
+    }
+    catch (AggregateException ae)
+    {
+        // Handle InnerException
+    }
+
+    // Construct reserved events with known fields Wager
+    var wager = new Wager
+        {
+          "$type"                 : "$wager",
+          "$api_key"              : "YOUR_API_KEY",
+          "$user_id"              : "billy_jones_301",
+          "$wager_id".            : "ID000001",
+          "$wager_type"           : "spread",
+          "$wager_status"         : "$accept",
+          "$amount"               : 506790000,
+          "$currency_code"        : "USD",
+          "$event_type"           : "Sportsbook",
+          "$event_name"           : "NFL",
+          "$event_id"             : "KHG23423093",
+          "$minimum_wager_amount" : 3000000
+        };
+
+    EventRequest eventRequest = new EventRequest()
+    {
+        Event = wager
+    };
+    try
+    {
+        EventResponse res = sift.SendAsync(eventRequest).Result;
+    }
+    catch (AggregateException ae)
+    {
+        // Handle InnerException
+    }
+
+
 #### IncludeScorePercentile in EventRequest
 
       EventRequest eventRequest = new EventRequest

--- a/Sift/Schema/transaction.json
+++ b/Sift/Schema/transaction.json
@@ -129,6 +129,30 @@
     },
     "$verification_phone_number": {
       "type": [ "string", "null" ]
+    },
+    "$minimum_deposit_amount": {
+      "type": [ "integer", "null" ],
+      "format": "long"
+    },
+    "$maximum_deposit_amount": {
+      "type": [ "integer", "null" ],
+      "format": "long"
+    },
+    "$minimum_withdrawal_amount": {
+      "type": [ "integer", "null" ],
+      "format": "long"
+    },
+    "$maximum_withdrawal_amount": {
+      "type": [ "integer", "null" ],
+      "format": "long"
+    },
+    "$current_balance": {
+      "type": [ "integer", "null" ],
+      "format": "long"
+    },
+    "$new_balance": {
+      "type": [ "integer", "null" ],
+      "format": "long"
     }
   }
 }

--- a/Sift/Schema/wager.json
+++ b/Sift/Schema/wager.json
@@ -11,9 +11,6 @@
     "$user_id": {
       "type": [ "string", "null" ]
     },
-    "$session_id": {
-      "type": [ "string", "null" ]
-    },
     "$wager_id": {
       "type": [ "string", "null" ]
     },

--- a/Sift/Schema/wager.json
+++ b/Sift/Schema/wager.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Wager",
+  "type": "object",
+  "required": [ "$type" ],
+  "properties": {
+    "$type": {
+      "type": "string",
+      "default": "$wager"
+    },
+    "$user_id": {
+      "type": [ "string", "null" ]
+    },
+    "$session_id": {
+      "type": [ "string", "null" ]
+    },
+    "$wager_id": {
+      "type": [ "string", "null" ]
+    },
+    "$wager_type": {
+      "type": [ "string", "null" ]
+    },
+    "$wager_status": {
+      "type": [ "string", "null" ]
+    },
+    "$amount": {
+      "type": [ "integer", "null" ],
+      "format": "long"
+    },
+    "$currency_code": {
+      "type": [ "string", "null" ]
+    },
+    "$wager_event_type": {
+      "type": [ "string", "null" ]
+    },
+    "$wager_event_name": {
+      "type": [ "string", "null" ]
+    },
+    "$wager_event_id": {
+      "type": [ "string", "null" ]
+    },
+    "$minimum_wager_amount": {
+      "type": [ "integer", "null" ],
+      "format": "long"
+    }          
+  }
+}

--- a/Sift/Sift.csproj
+++ b/Sift/Sift.csproj
@@ -4,8 +4,8 @@
     <Authors>Sift</Authors>
     <AssemblyTitle>Sift</AssemblyTitle>
     <AssemblyName>Sift</AssemblyName>
-    <VersionPrefix>1.4.0</VersionPrefix>
-    <PackageReleaseNotes>Release 1.4.0</PackageReleaseNotes>
+    <VersionPrefix>1.5.0</VersionPrefix>
+    <PackageReleaseNotes>Release 1.5.0</PackageReleaseNotes>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>Sift</PackageId>
     <PackageTags>sift;siftscience;client;api;client;async</PackageTags>

--- a/Test.Integration.Net7/EventsAPI/Transactions.cs
+++ b/Test.Integration.Net7/EventsAPI/Transactions.cs
@@ -179,5 +179,66 @@ namespace Test.Integration.Net7.EventsAPI
             EventResponse res = sift.SendAsync(eventRequest).Result;
             Assert.Equal("0", res.Status.ToString());
         }
+
+        [Fact]
+        public void DepositTransactionTest()
+        {
+            var sift = new Client(ApiKey);
+            var transaction = new Transaction
+            {
+                user_id = UserId,
+                user_email = UserEmail,
+                amount = 60000000,
+                currency_code = "EUR",
+                transaction_type = "$deposit",
+                transaction_status = "$success",
+                payment_method =  new PaymentMethod()
+                {
+                    wallet_address = "wallet1",
+                    wallet_type = "$digital"
+                },
+                minimum_deposit_amount = 10000,
+                maximum_deposit_amount = 60000000,
+                current_balance = 0,
+                new_balance = 506790000
+            };
+            EventRequest eventRequest = new EventRequest()
+            {
+                Event = transaction
+            };
+            EventResponse res = sift.SendAsync(eventRequest).Result;
+            Assert.Equal("0", res.Status.ToString());
+        }
+
+        [Fact]
+        public void WithdrawalTransactionTest()
+        {
+            var sift = new Client(ApiKey);
+            var transaction = new Transaction
+            {
+                user_id = UserId,
+                user_email = UserEmail,
+                amount = 60000000,
+                currency_code = "EUR",
+                transaction_type = "$withdrawal",
+                transaction_status = "$success",
+                payment_method =  new PaymentMethod()
+                {
+                    wallet_address = "wallet1",
+                    wallet_type = "$digital"
+                },
+
+                minimum_withdrawal_amount = 10000,
+                maximum_withdrawal_amount = 60000000,
+                current_balance = 60000000,
+                new_balance = 0
+            };
+            EventRequest eventRequest = new EventRequest()
+            {
+                Event = transaction
+            };
+            EventResponse res = sift.SendAsync(eventRequest).Result;
+            Assert.Equal("0", res.Status.ToString());
+        }
     }
 }

--- a/Test.Integration.Net7/EventsAPI/Wagers.cs
+++ b/Test.Integration.Net7/EventsAPI/Wagers.cs
@@ -11,7 +11,6 @@ namespace Test.Integration.Net7.EventsAPI
         private readonly EnvironmentVariable environmentVariable = new();
         private readonly string ApiKey;
         private readonly string UserId;
-        private readonly string SessionId;
         private readonly string WagerId;
 
 

--- a/Test.Integration.Net7/EventsAPI/Wagers.cs
+++ b/Test.Integration.Net7/EventsAPI/Wagers.cs
@@ -1,0 +1,55 @@
+using Sift;
+using System;
+using System.Diagnostics;
+using Test.Integration.Net7.Uitlities;
+using Xunit;
+
+namespace Test.Integration.Net7.EventsAPI
+{
+    public class Wagers
+    {
+        private readonly EnvironmentVariable environmentVariable = new();
+        private readonly string ApiKey;
+        private readonly string UserId;
+        private readonly string SessionId;
+        private readonly string WagerId;
+
+
+        public Wagers()
+        {
+            ApiKey = environmentVariable.ApiKey;
+            UserId = environmentVariable.user_id;
+
+            long nowMills = DateTimeOffset.Now.ToUnixTimeMilliseconds();
+            WagerId = "wager-" + nowMills;
+        }
+
+        [Fact]
+        public void WagerTest()
+        {
+            var sift = new Client(ApiKey);
+            var wager = new Wager
+            {
+                user_id = UserId,
+                wager_id = WagerId,
+                wager_type = "$parlay",
+                wager_status = "$accept",
+                amount = 5000,
+                currency_code = "USD",
+                minimum_wager_amount = 100L,
+                wager_event_type = "NBA",
+                wager_event_name = "Bulls-Lakers",
+                wager_event_id = "nfl-23-11100"
+            };
+
+            EventRequest eventRequest = new EventRequest()
+            {
+                Event = wager
+            };
+
+            EventResponse res = sift.SendAsync(eventRequest).Result;
+            Assert.Equal("0", res.Status.ToString()); // Check for successful response
+        }
+
+    }
+}

--- a/Test.Integration.NetFx48/EventsAPI/Transactions.cs
+++ b/Test.Integration.NetFx48/EventsAPI/Transactions.cs
@@ -175,5 +175,66 @@ namespace Test.Integration.NetFx48.EventsAPI
             EventResponse res = sift.SendAsync(eventRequest).Result;
             Assert.Equal("0", res.Status.ToString());
         }
+
+        [Fact]
+        public void DepositTransactionTest()
+        {
+            var sift = new Client(ApiKey);
+            var transaction = new Transaction
+            {
+                user_id = UserId,
+                user_email = UserEmail,
+                amount = 60000000,
+                currency_code = "EUR",
+                transaction_type = "$deposit",
+                transaction_status = "$success",
+                payment_method =  new PaymentMethod()
+                {
+                    wallet_address = "wallet1",
+                    wallet_type = "$digital"
+                },
+                minimum_deposit_amount = 10000,
+                maximum_deposit_amount = 60000000,
+                current_balance = 0,
+                new_balance = 506790000
+            };
+            EventRequest eventRequest = new EventRequest()
+            {
+                Event = transaction
+            };
+            EventResponse res = sift.SendAsync(eventRequest).Result;
+            Assert.Equal("0", res.Status.ToString());
+        }
+
+        [Fact]
+        public void WithdrawalTransactionTest()
+        {
+            var sift = new Client(ApiKey);
+            var transaction = new Transaction
+            {
+                user_id = UserId,
+                user_email = UserEmail,
+                amount = 60000000,
+                currency_code = "EUR",
+                transaction_type = "$withdrawal",
+                transaction_status = "$success",
+                payment_method =  new PaymentMethod()
+                {
+                    wallet_address = "wallet1",
+                    wallet_type = "$digital"
+                },
+
+                minimum_withdrawal_amount = 10000,
+                maximum_withdrawal_amount = 60000000,
+                current_balance = 60000000,
+                new_balance = 0
+            };
+            EventRequest eventRequest = new EventRequest()
+            {
+                Event = transaction
+            };
+            EventResponse res = sift.SendAsync(eventRequest).Result;
+            Assert.Equal("0", res.Status.ToString());
+        }
     }
 }

--- a/Test.Integration.NetFx48/EventsAPI/Wagers.cs
+++ b/Test.Integration.NetFx48/EventsAPI/Wagers.cs
@@ -16,7 +16,7 @@ namespace Test.Integration.NetFx48.EventsAPI
 
         public Wagers()
         {
-            ApiKey = "8e6580678c3f1983"; // environmentVariable.ApiKey;
+            ApiKey = environmentVariable.ApiKey;
             UserId = environmentVariable.user_id;
 
             long nowMills = DateTimeOffset.Now.ToUnixTimeMilliseconds();

--- a/Test.Integration.NetFx48/EventsAPI/Wagers.cs
+++ b/Test.Integration.NetFx48/EventsAPI/Wagers.cs
@@ -1,0 +1,53 @@
+using Sift;
+using System;
+using System.Diagnostics;
+using Test.Integration.NetFx48.Uitlities;
+using Xunit;
+
+namespace Test.Integration.NetFx48.EventsAPI
+{
+    public class Wagers
+    {
+        private readonly EnvironmentVariable environmentVariable = new EnvironmentVariable();
+        private readonly string ApiKey;
+        private readonly string UserId;
+        private readonly string WagerId;
+
+
+        public Wagers()
+        {
+            ApiKey = "8e6580678c3f1983"; // environmentVariable.ApiKey;
+            UserId = environmentVariable.user_id;
+
+            long nowMills = DateTimeOffset.Now.ToUnixTimeMilliseconds();
+            WagerId = "wager-" + nowMills; // Ensure unique wager IDs
+        }
+
+        [Fact]
+        public void WagerTest()
+        {
+            var sift = new Client(ApiKey);
+            var wager = new Wager
+            {
+                user_id = UserId,
+                wager_id = WagerId,
+                wager_type = "$parlay",
+                wager_status = "$accept",
+                amount = 5000,
+                currency_code = "USD",
+                minimum_wager_amount = 100L,
+                wager_event_type = "NBA",
+                wager_event_name = "Bulls-Lakers",
+                wager_event_id = "nfl-23-11100"
+            };
+
+            EventRequest eventRequest = new EventRequest()
+            {
+                Event = wager
+            };
+
+            EventResponse res = sift.SendAsync(eventRequest).Result;
+            Assert.Equal("0", res.Status.ToString()); // Check for successful response
+        }
+    }
+}

--- a/Test/Test.cs
+++ b/Test/Test.cs
@@ -2756,7 +2756,6 @@ namespace Test
         [Fact]
         public void TestWagerEvent()
         {
-            var sessionId = "sessionId";
             var wager = new Wager
             {
                 user_id = "test_dotnet_wager_event",

--- a/Test/Test.cs
+++ b/Test/Test.cs
@@ -2627,6 +2627,181 @@ namespace Test
 
         }
 
+        [Fact]
+        public void TestTransactionEventWithExtraDepositFields()
+        {
+            //Please provide the valid session id in place of 'sessionId'
+            var sessionId = "sessionId";
+            var transaction = new Transaction
+            {
+                user_id = "test_dotnet_transaction_event",
+                amount = 1000000000000L,
+                currency_code = "USD",
+                session_id = sessionId,
+                transaction_type = "$deposit",
+                transaction_status = "$failure",
+                payment_method = new PaymentMethod
+                {
+                    wallet_address = "ZplYVmchAoywfMvC8jCiKlBLfKSBiFtHU6",
+                    wallet_type = "$crypto"
+                }
+                ,
+                minimum_deposit_amount = 100000L,
+                maximum_deposit_amount = 1000000000000L,
+                current_balance = 0L,
+                new_balance = 1000000000000L
+            };
+
+            Assert.Equal("{" +
+            "\"$type\":\"$transaction\"," +
+            "\"$user_id\":\"test_dotnet_transaction_event\"," +
+            "\"$session_id\":\"sessionId\"," +
+            "\"$transaction_type\":\"$deposit\"," +
+
+            "\"$transaction_status\":\"$failure\"," +
+            "\"$amount\":1000000000000," +
+            "\"$currency_code\":\"USD\"," +
+            "" +
+            "\"$payment_method\":{" +
+            "\"$wallet_address\":\"ZplYVmchAoywfMvC8jCiKlBLfKSBiFtHU6\"," +
+            "\"$wallet_type\":\"$crypto\"" +
+            "}," +
+            "\"$minimum_deposit_amount\":100000," +
+            "\"$maximum_deposit_amount\":1000000000000," +
+            "\"$current_balance\":0," +
+            "\"$new_balance\":1000000000000" +
+            "}", transaction.ToJson());
+
+            EventRequest eventRequest = new EventRequest
+            {
+                Event = transaction
+            };
+
+            Assert.Equal("https://api.sift.com/v205/events", eventRequest.Request.RequestUri!.ToString());
+
+            eventRequest = new EventRequest
+            {
+                Event = transaction,
+                AbuseTypes = { "legacy", "payment_abuse" },
+                ReturnScore = true
+            };
+
+            Assert.Equal("https://api.sift.com/v205/events?abuse_types=legacy,payment_abuse&return_score=true",
+                          Uri.UnescapeDataString(eventRequest.Request.RequestUri!.ToString()));
+        }
+
+        [Fact]
+        public void TestTransactionEventWithExtraWithdrawalFields()
+        {
+            //Please provide the valid session id in place of 'sessionId'
+            var sessionId = "sessionId";
+            var transaction = new Transaction
+            {
+                user_id = "test_dotnet_transaction_event",
+                amount = 1000000000000L,
+                currency_code = "USD",
+                session_id = sessionId,
+                transaction_type = "$withdrawal",
+                transaction_status = "$failure",
+                payment_method = new PaymentMethod
+                {
+                    wallet_address = "ZplYVmchAoywfMvC8jCiKlBLfKSBiFtHU6",
+                    wallet_type = "$crypto"
+                }
+                ,
+                minimum_withdrawal_amount = 100000L,
+                maximum_withdrawal_amount = 1000000000000L,
+                current_balance = 1000000000000L,
+                new_balance = 0
+            };
+
+            Assert.Equal("{" +
+            "\"$type\":\"$transaction\"," +
+            "\"$user_id\":\"test_dotnet_transaction_event\"," +
+            "\"$session_id\":\"sessionId\"," +
+            "\"$transaction_type\":\"$withdrawal\"," +
+
+            "\"$transaction_status\":\"$failure\"," +
+            "\"$amount\":1000000000000," +
+            "\"$currency_code\":\"USD\"," +
+            "" +
+            "\"$payment_method\":{" +
+            "\"$wallet_address\":\"ZplYVmchAoywfMvC8jCiKlBLfKSBiFtHU6\"," +
+            "\"$wallet_type\":\"$crypto\"" +
+            "}," +
+            "\"$minimum_withdrawal_amount\":100000," +
+            "\"$maximum_withdrawal_amount\":1000000000000," +
+            "\"$current_balance\":1000000000000," +
+            "\"$new_balance\":0" +
+            "}", transaction.ToJson());
+
+            EventRequest eventRequest = new EventRequest
+            {
+                Event = transaction
+            };
+
+            Assert.Equal("https://api.sift.com/v205/events", eventRequest.Request.RequestUri!.ToString());
+
+            eventRequest = new EventRequest
+            {
+                Event = transaction,
+                AbuseTypes = { "legacy", "payment_abuse" },
+                ReturnScore = true
+            };
+
+            Assert.Equal("https://api.sift.com/v205/events?abuse_types=legacy,payment_abuse&return_score=true",
+                          Uri.UnescapeDataString(eventRequest.Request.RequestUri!.ToString()));
+        }
+
+        [Fact]
+        public void TestWagerEvent()
+        {
+            var sessionId = "sessionId";
+            var wager = new Wager
+            {
+                user_id = "test_dotnet_wager_event",
+                wager_id = "wager123",
+                wager_type = "$parlay",
+                wager_status = "$accept",
+                amount = 5000L,
+                currency_code = "USD",
+                wager_event_type = "NFL",
+                wager_event_name = "Example Game",
+                wager_event_id = "event456",
+                minimum_wager_amount = 100L
+            };
+
+            Assert.Equal("{" +
+                "\"$type\":\"$wager\"," +
+                "\"$user_id\":\"test_dotnet_wager_event\"," +
+                "\"$wager_id\":\"wager123\"," +
+                "\"$wager_type\":\"$parlay\"," +
+                "\"$wager_status\":\"$accept\"," +
+                "\"$amount\":5000," +
+                "\"$currency_code\":\"USD\"," +
+                "\"$wager_event_type\":\"NFL\"," +
+                "\"$wager_event_name\":\"Example Game\"," +
+                "\"$wager_event_id\":\"event456\"," +
+                "\"$minimum_wager_amount\":100" +
+                "}", wager.ToJson());
+
+            EventRequest eventRequest = new EventRequest
+            {
+                Event = wager
+            };
+
+            Assert.Equal("https://api.sift.com/v205/events", eventRequest.Request.RequestUri!.ToString());
+
+            eventRequest = new EventRequest
+            {
+                Event = wager,
+                AbuseTypes = { "legacy", "payment_abuse" },
+                ReturnScore = true
+            };
+
+            Assert.Equal("https://api.sift.com/v205/events?abuse_types=legacy,payment_abuse&return_score=true",
+                          Uri.UnescapeDataString(eventRequest.Request.RequestUri!.ToString()));
+        }
     }
 
 }


### PR DESCRIPTION
## Purpose
Add support for iGaming Events API changes:
- extra fields for `$deposit` and `$withdrawal` Transactions
- new event type `$wager`

## Summary
Added support for the new fields and event type, lib version has been updated for a new release.

## Testing
Changes are covered with unit and integration tests.

## Checklist
- [x] The change was thoroughly tested manually
- [x] The change was covered with unit tests
- [x] The change was tested with real API calls (if applicable)
- [x] Necessary changes were made in the integration tests (if applicable)
- [x] New functionality is reflected in README
