### PR TITLE
Add Global Profile API support

### DIFF
--- a/CHANGES.MD
+++ b/CHANGES.MD
@@ -1,4 +1,11 @@
-# CHANGES
+﻿# CHANGES
+
+## 1.8.0 (2026-08-18)
+
+### Added
+- **Global Profile API** support: `GlobalProfileRequest`/`GlobalProfileResponse` for
+  `GET /v3/accounts/{accountId}/global_profile/users/{userId}` and
+  `GlobalProfileLookupRequest` for `POST /v3/accounts/{accountId}/global_profile/lookup`
 
 ## 1.7.0 (2025-12-03)
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 The official Sift .NET client, supporting .NET Standard 2.0+
 
-## Latest Release (v1.7.0)
+## Latest Release (v1.8.0)
 
 See [CHANGES.MD](CHANGES.MD) for full release history.
 
@@ -1045,6 +1045,40 @@ var booking = new Booking
         GetDecisionsResponse response = sift.SendAsync(new GetDecisionsRequest
         {
             AccountId = "ACCOUNT_ID"
+        }).Result;
+    }
+    catch (AggregateException ae)
+    {
+        // Handle InnerException
+    }
+
+### Global Profile
+
+    // Get Global Profile for a user
+    try
+    {
+        GlobalProfileResponse response = sift.SendAsync(new GlobalProfileRequest
+        {
+            AccountId = "ACCOUNT_ID",
+            UserId = "gary",
+            GlobalOnly = false,
+            IncludeOwnData = true
+        }).Result;
+    }
+    catch (AggregateException ae)
+    {
+        // Handle InnerException
+    }
+
+    // Look up a Global Profile by email and/or phone.
+    // At least one of Email or Phone is required; omitting both throws a MissingFieldException.
+    try
+    {
+        GlobalProfileResponse response = sift.SendAsync(new GlobalProfileLookupRequest
+        {
+            AccountId = "ACCOUNT_ID",
+            Email = "gary@example.com",
+            Phone = "+15555550100"
         }).Result;
     }
     catch (AggregateException ae)

--- a/Sift/Core/Client.cs
+++ b/Sift/Core/Client.cs
@@ -120,6 +120,16 @@ namespace Sift
             return await SendAsync<GetMerchantDetailsResponse>(getMerchantRequest);
         }
 
+        public async Task<GlobalProfileResponse> SendAsync(GlobalProfileRequest globalProfileRequest)
+        {
+            return await SendAsync<GlobalProfileResponse>(globalProfileRequest);
+        }
+
+        public async Task<GlobalProfileResponse> SendAsync(GlobalProfileLookupRequest globalProfileLookupRequest)
+        {
+            return await SendAsync<GlobalProfileResponse>(globalProfileLookupRequest);
+        }
+
         async Task<T> SendAsync<T>(SiftRequest siftRequest) where T : SiftResponse
         {
             siftRequest.ApiKey = this.apiKey;

--- a/Sift/Request/GlobalProfileRequest.cs
+++ b/Sift/Request/GlobalProfileRequest.cs
@@ -1,0 +1,94 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+
+namespace Sift
+{
+    public class GlobalProfileRequest : SiftRequest
+    {
+        static readonly String GlobalProfileUrl = @"https://api.sift.com/v3/accounts/{0}/global_profile/users/{1}";
+
+        public string AccountId { get; set; }
+        public string UserId { get; set; }
+        public bool? GlobalOnly { get; set; }
+        public bool? IncludeOwnData { get; set; }
+
+        public override HttpRequestMessage Request
+        {
+            get
+            {
+                var request = new HttpRequestMessage(HttpMethod.Get, Url);
+                request.Headers.Authorization = new AuthenticationHeaderValue("Basic", Convert.ToBase64String(Encoding.Default.GetBytes(ApiKey)));
+                return request;
+            }
+        }
+
+        protected override Uri Url
+        {
+            get
+            {
+                var url = new Uri(String.Format(GlobalProfileUrl,
+                                                Uri.EscapeDataString(AccountId),
+                                                Uri.EscapeDataString(UserId)));
+
+                if (GlobalOnly.HasValue)
+                {
+                    url = url.AddQuery("global_only", GlobalOnly.Value.ToString().ToLowerInvariant());
+                }
+
+                if (IncludeOwnData.HasValue)
+                {
+                    url = url.AddQuery("include_own_data", IncludeOwnData.Value.ToString().ToLowerInvariant());
+                }
+
+                return url;
+            }
+        }
+    }
+
+    public class GlobalProfileLookupRequest : SiftRequest
+    {
+        static readonly String GlobalProfileLookupUrl = @"https://api.sift.com/v3/accounts/{0}/global_profile/lookup";
+
+        [JsonIgnore]
+        public string AccountId { get; set; }
+
+        [JsonIgnore]
+        public override string ApiKey { get; set; }
+
+        [JsonProperty("email", NullValueHandling = NullValueHandling.Ignore)]
+        public string Email { get; set; }
+
+        [JsonProperty("phone", NullValueHandling = NullValueHandling.Ignore)]
+        public string Phone { get; set; }
+
+        [JsonIgnore]
+        public override HttpRequestMessage Request
+        {
+            get
+            {
+                if (String.IsNullOrEmpty(Email) && String.IsNullOrEmpty(Phone))
+                {
+                    throw new MissingFieldException("At least one of Email or Phone is required.");
+                }
+
+                var request = new HttpRequestMessage(HttpMethod.Post, Url);
+                request.Headers.Authorization = new AuthenticationHeaderValue("Basic", Convert.ToBase64String(Encoding.Default.GetBytes(ApiKey)));
+                request.Content = new StringContent(JsonConvert.SerializeObject(this), Encoding.UTF8, "application/json");
+                return request;
+            }
+        }
+
+        [JsonIgnore]
+        protected override Uri Url
+        {
+            get
+            {
+                return new Uri(String.Format(GlobalProfileLookupUrl,
+                                             Uri.EscapeDataString(AccountId)));
+            }
+        }
+    }
+}

--- a/Sift/Response/GlobalProfileResponse.cs
+++ b/Sift/Response/GlobalProfileResponse.cs
@@ -1,0 +1,179 @@
+﻿using Newtonsoft.Json;
+using System.Collections.Generic;
+
+namespace Sift
+{
+    public class GlobalProfileResponse : SiftResponse
+    {
+        [JsonProperty("error_code")]
+        public int? ErrorCode { get; set; }
+
+        [JsonProperty("lookback_months")]
+        public int? LookbackMonths { get; set; }
+
+        [JsonProperty("profile_summary")]
+        public ProfileSummaryJson ProfileSummary { get; set; }
+
+        [JsonProperty("identity_age")]
+        public IdentityAgeJson IdentityAge { get; set; }
+
+        [JsonProperty("user_decisions")]
+        public UserDecisionsJson UserDecisions { get; set; }
+
+        [JsonProperty("chargebacks")]
+        public ChargebacksJson Chargebacks { get; set; }
+
+        [JsonProperty("orders")]
+        public OrdersJson Orders { get; set; }
+
+        [JsonProperty("transactions")]
+        public TransactionsJson Transactions { get; set; }
+
+        [JsonProperty("locations")]
+        public LocationsJson Locations { get; set; }
+
+        public class ProfileSummaryJson
+        {
+            [JsonProperty("identity_found")]
+            public bool IdentityFound { get; set; }
+
+            [JsonProperty("has_links")]
+            public bool HasLinks { get; set; }
+
+            [JsonProperty("link_count")]
+            public int LinkCount { get; set; }
+
+            [JsonProperty("linked_accounts_count_per_industry")]
+            public Dictionary<string, int> LinkedAccountsCountPerIndustry { get; set; }
+        }
+
+        public class IdentityAgeJson
+        {
+            [JsonProperty("oldest_account_age_timestamp")]
+            public long? OldestAccountAgeTimestamp { get; set; }
+
+            [JsonProperty("newest_account_age_timestamp")]
+            public long? NewestAccountAgeTimestamp { get; set; }
+
+            [JsonProperty("average_account_age_timestamp")]
+            public long? AverageAccountAgeTimestamp { get; set; }
+        }
+
+        public class UserDecisionsJson
+        {
+            [JsonProperty("total")]
+            public int Total { get; set; }
+
+            [JsonProperty("blocked")]
+            public int Blocked { get; set; }
+
+            [JsonProperty("watched")]
+            public int Watched { get; set; }
+
+            [JsonProperty("accepted")]
+            public int Accepted { get; set; }
+
+            [JsonProperty("manual")]
+            public int Manual { get; set; }
+
+            [JsonProperty("auto")]
+            public int Auto { get; set; }
+
+            [JsonProperty("last_type")]
+            public string LastType { get; set; }
+
+            [JsonProperty("last_timestamp")]
+            public long? LastTimestamp { get; set; }
+        }
+
+        public class ChargebacksJson
+        {
+            [JsonProperty("total")]
+            public int Total { get; set; }
+
+            [JsonProperty("fraudulent")]
+            public int Fraudulent { get; set; }
+
+            [JsonProperty("other")]
+            public int Other { get; set; }
+
+            [JsonProperty("last_timestamp")]
+            public long? LastTimestamp { get; set; }
+
+            [JsonProperty("last_fraudulent_timestamp")]
+            public long? LastFraudulentTimestamp { get; set; }
+        }
+
+        public class OrdersJson
+        {
+            [JsonProperty("total")]
+            public int Total { get; set; }
+
+            [JsonProperty("blocked")]
+            public int Blocked { get; set; }
+
+            [JsonProperty("watched")]
+            public int Watched { get; set; }
+
+            [JsonProperty("accepted")]
+            public int Accepted { get; set; }
+
+            [JsonProperty("last_timestamp")]
+            public long? LastTimestamp { get; set; }
+
+            [JsonProperty("last_blocked_timestamp")]
+            public long? LastBlockedTimestamp { get; set; }
+        }
+
+        public class TransactionsJson
+        {
+            [JsonProperty("total")]
+            public int Total { get; set; }
+
+            [JsonProperty("failed_fraud")]
+            public int FailedFraud { get; set; }
+
+            [JsonProperty("failed_other")]
+            public int FailedOther { get; set; }
+
+            [JsonProperty("successful")]
+            public int Successful { get; set; }
+
+            [JsonProperty("last_timestamp")]
+            public long? LastTimestamp { get; set; }
+
+            [JsonProperty("last_failed_fraud_timestamp")]
+            public long? LastFailedFraudTimestamp { get; set; }
+        }
+
+        public class LocationsJson
+        {
+            [JsonProperty("unique_billing_addresses")]
+            public int UniqueBillingAddresses { get; set; }
+
+            [JsonProperty("unique_shipping_addresses")]
+            public int UniqueShippingAddresses { get; set; }
+
+            [JsonProperty("distinct_countries_count")]
+            public int DistinctCountriesCount { get; set; }
+
+            [JsonProperty("distinct_regions_count")]
+            public int DistinctRegionsCount { get; set; }
+
+            [JsonProperty("location_connected_accounts")]
+            public List<LocationConnectedAccountJson> LocationConnectedAccounts { get; set; }
+
+            [JsonProperty("location_last_used_timestamp")]
+            public long? LocationLastUsedTimestamp { get; set; }
+        }
+
+        public class LocationConnectedAccountJson
+        {
+            [JsonProperty("city")]
+            public string City { get; set; }
+
+            [JsonProperty("country")]
+            public string Country { get; set; }
+        }
+    }
+}

--- a/Sift/Response/GlobalProfileResponse.cs
+++ b/Sift/Response/GlobalProfileResponse.cs
@@ -38,13 +38,13 @@ namespace Sift
             public bool IdentityFound { get; set; }
 
             [JsonProperty("has_links")]
-            public bool HasLinks { get; set; }
+            public bool? HasLinks { get; set; }
 
             [JsonProperty("link_count")]
-            public int LinkCount { get; set; }
+            public int? LinkCount { get; set; }
 
             [JsonProperty("linked_accounts_count_per_industry")]
-            public Dictionary<string, int> LinkedAccountsCountPerIndustry { get; set; }
+            public Dictionary<string, long> LinkedAccountsCountPerIndustry { get; set; }
         }
 
         public class IdentityAgeJson
@@ -62,22 +62,22 @@ namespace Sift
         public class UserDecisionsJson
         {
             [JsonProperty("total")]
-            public int Total { get; set; }
+            public long Total { get; set; }
 
             [JsonProperty("blocked")]
-            public int Blocked { get; set; }
+            public long Blocked { get; set; }
 
             [JsonProperty("watched")]
-            public int Watched { get; set; }
+            public long Watched { get; set; }
 
             [JsonProperty("accepted")]
-            public int Accepted { get; set; }
+            public long Accepted { get; set; }
 
             [JsonProperty("manual")]
-            public int Manual { get; set; }
+            public long Manual { get; set; }
 
             [JsonProperty("auto")]
-            public int Auto { get; set; }
+            public long Auto { get; set; }
 
             [JsonProperty("last_type")]
             public string LastType { get; set; }
@@ -89,13 +89,13 @@ namespace Sift
         public class ChargebacksJson
         {
             [JsonProperty("total")]
-            public int Total { get; set; }
+            public long Total { get; set; }
 
             [JsonProperty("fraudulent")]
-            public int Fraudulent { get; set; }
+            public long Fraudulent { get; set; }
 
             [JsonProperty("other")]
-            public int Other { get; set; }
+            public long Other { get; set; }
 
             [JsonProperty("last_timestamp")]
             public long? LastTimestamp { get; set; }
@@ -107,16 +107,16 @@ namespace Sift
         public class OrdersJson
         {
             [JsonProperty("total")]
-            public int Total { get; set; }
+            public long Total { get; set; }
 
             [JsonProperty("blocked")]
-            public int Blocked { get; set; }
+            public long Blocked { get; set; }
 
             [JsonProperty("watched")]
-            public int Watched { get; set; }
+            public long Watched { get; set; }
 
             [JsonProperty("accepted")]
-            public int Accepted { get; set; }
+            public long Accepted { get; set; }
 
             [JsonProperty("last_timestamp")]
             public long? LastTimestamp { get; set; }
@@ -128,16 +128,16 @@ namespace Sift
         public class TransactionsJson
         {
             [JsonProperty("total")]
-            public int Total { get; set; }
+            public long Total { get; set; }
 
             [JsonProperty("failed_fraud")]
-            public int FailedFraud { get; set; }
+            public long FailedFraud { get; set; }
 
             [JsonProperty("failed_other")]
-            public int FailedOther { get; set; }
+            public long FailedOther { get; set; }
 
             [JsonProperty("successful")]
-            public int Successful { get; set; }
+            public long Successful { get; set; }
 
             [JsonProperty("last_timestamp")]
             public long? LastTimestamp { get; set; }
@@ -149,16 +149,16 @@ namespace Sift
         public class LocationsJson
         {
             [JsonProperty("unique_billing_addresses")]
-            public int UniqueBillingAddresses { get; set; }
+            public long UniqueBillingAddresses { get; set; }
 
             [JsonProperty("unique_shipping_addresses")]
-            public int UniqueShippingAddresses { get; set; }
+            public long UniqueShippingAddresses { get; set; }
 
             [JsonProperty("distinct_countries_count")]
-            public int DistinctCountriesCount { get; set; }
+            public long DistinctCountriesCount { get; set; }
 
             [JsonProperty("distinct_regions_count")]
-            public int DistinctRegionsCount { get; set; }
+            public long DistinctRegionsCount { get; set; }
 
             [JsonProperty("location_connected_accounts")]
             public List<LocationConnectedAccountJson> LocationConnectedAccounts { get; set; }
@@ -174,6 +174,9 @@ namespace Sift
 
             [JsonProperty("country")]
             public string Country { get; set; }
+
+            [JsonProperty("region")]
+            public string Region { get; set; }
         }
     }
 }

--- a/Sift/Sift.csproj
+++ b/Sift/Sift.csproj
@@ -4,8 +4,8 @@
     <Authors>Sift</Authors>
     <AssemblyTitle>Sift</AssemblyTitle>
     <AssemblyName>Sift</AssemblyName>
-    <VersionPrefix>1.7.0</VersionPrefix>
-    <PackageReleaseNotes>Release 1.7.0</PackageReleaseNotes>
+    <VersionPrefix>1.8.0</VersionPrefix>
+    <PackageReleaseNotes>Release 1.8.0</PackageReleaseNotes>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>Sift</PackageId>
     <PackageTags>sift;siftscience;client;api;client;async</PackageTags>

--- a/Test/Test.cs
+++ b/Test/Test.cs
@@ -1149,6 +1149,25 @@ namespace Test
         }
 
         [Fact]
+        public void TestGlobalProfileLookupRequestWithEmailOnly()
+        {
+            var accountId = "12345678";
+            var apiKey = "key";
+            var globalProfileLookupRequest = new GlobalProfileLookupRequest
+            {
+                AccountId = accountId,
+                Email = "gary@example.com"
+            };
+            globalProfileLookupRequest.ApiKey = apiKey;
+
+            Assert.Equal("https://api.sift.com/v3/accounts/" + accountId + "/global_profile/lookup",
+                         globalProfileLookupRequest.Request.RequestUri!.ToString());
+
+            Assert.Equal("{\"email\":\"gary@example.com\"}",
+                         JsonConvert.SerializeObject(globalProfileLookupRequest));
+        }
+
+        [Fact]
         public void TestGlobalProfileLookupRequestRequiresEmailOrPhone()
         {
             var globalProfileLookupRequest = new GlobalProfileLookupRequest
@@ -1200,7 +1219,7 @@ namespace Test
                 "\"locations\":{" +
                     "\"unique_billing_addresses\":2,\"unique_shipping_addresses\":4," +
                     "\"distinct_countries_count\":3,\"distinct_regions_count\":5," +
-                    "\"location_connected_accounts\":[{\"city\":\"Kyiv\",\"country\":\"UA\"}]," +
+                    "\"location_connected_accounts\":[{\"city\":\"Kyiv\",\"country\":\"UA\",\"region\":\"Kyiv Oblast\"}]," +
                     "\"location_last_used_timestamp\":1881090536" +
                 "}" +
             "}";
@@ -1211,15 +1230,17 @@ namespace Test
             Assert.Equal(12, response.LookbackMonths);
             Assert.True(response.ProfileSummary!.IdentityFound);
             Assert.Equal(7, response.ProfileSummary.LinkCount);
-            Assert.Equal(3, response.ProfileSummary.LinkedAccountsCountPerIndustry!["finances"]);
+            Assert.Equal(3L, response.ProfileSummary.LinkedAccountsCountPerIndustry!["finances"]);
             Assert.Equal(1681090536, response.IdentityAge!.OldestAccountAgeTimestamp);
-            Assert.Equal(12, response.UserDecisions!.Total);
-            Assert.Equal(3, response.Chargebacks!.Total);
-            Assert.Equal(50, response.Orders!.Total);
-            Assert.Equal(120, response.Transactions!.Total);
-            Assert.Equal(2, response.Locations!.UniqueBillingAddresses);
+            Assert.Equal(12L, response.UserDecisions!.Total);
+            Assert.Equal(3L, response.Chargebacks!.Total);
+            Assert.Equal(50L, response.Orders!.Total);
+            Assert.Equal(120L, response.Transactions!.Total);
+            Assert.Equal(2L, response.Locations!.UniqueBillingAddresses);
             Assert.Single(response.Locations.LocationConnectedAccounts!);
             Assert.Equal("Kyiv", response.Locations.LocationConnectedAccounts![0].City);
+            Assert.Equal("UA", response.Locations.LocationConnectedAccounts![0].Country);
+            Assert.Equal("Kyiv Oblast", response.Locations.LocationConnectedAccounts![0].Region);
         }
 
         [Fact]

--- a/Test/Test.cs
+++ b/Test/Test.cs
@@ -1176,7 +1176,7 @@ namespace Test
             };
             globalProfileLookupRequest.ApiKey = "key";
 
-            Assert.Throws<MissingFieldException>(
+            Assert.Throws<Sift.MissingFieldException>(
                 () => globalProfileLookupRequest.Request
             );
         }

--- a/Test/Test.cs
+++ b/Test/Test.cs
@@ -1084,6 +1084,178 @@ namespace Test
         }
 
         [Fact]
+        public void TestGlobalProfileRequest()
+        {
+            //Please provide the valid account id in place of dummy number;
+            var accountId = "12345678";
+            var userId = "user-1";
+            //Please provide the valid api key in place of 'key'
+            var apiKey = "key";
+            var globalProfileRequest = new GlobalProfileRequest
+            {
+                AccountId = accountId,
+                UserId = userId
+            };
+            globalProfileRequest.ApiKey = apiKey;
+
+            Assert.Equal(Convert.ToBase64String(Encoding.Default.GetBytes(apiKey)),
+                globalProfileRequest.Request.Headers.Authorization!.Parameter);
+
+            Assert.Equal("https://api.sift.com/v3/accounts/" + accountId + "/global_profile/users/" + userId,
+                         globalProfileRequest.Request.RequestUri!.ToString());
+        }
+
+        [Fact]
+        public void TestGlobalProfileRequestWithQueryParams()
+        {
+            var accountId = "12345678";
+            var userId = "user-1";
+            var apiKey = "key";
+            var globalProfileRequest = new GlobalProfileRequest
+            {
+                AccountId = accountId,
+                UserId = userId,
+                GlobalOnly = true,
+                IncludeOwnData = false
+            };
+            globalProfileRequest.ApiKey = apiKey;
+
+            Assert.Equal("https://api.sift.com/v3/accounts/" + accountId + "/global_profile/users/" + userId +
+                         "?global_only=true&include_own_data=false",
+                         Uri.UnescapeDataString(globalProfileRequest.Request.RequestUri!.ToString()));
+        }
+
+        [Fact]
+        public void TestGlobalProfileLookupRequest()
+        {
+            var accountId = "12345678";
+            var apiKey = "key";
+            var globalProfileLookupRequest = new GlobalProfileLookupRequest
+            {
+                AccountId = accountId,
+                Email = "gary@example.com",
+                Phone = "+15555550100"
+            };
+            globalProfileLookupRequest.ApiKey = apiKey;
+
+            Assert.Equal(Convert.ToBase64String(Encoding.Default.GetBytes(apiKey)),
+                globalProfileLookupRequest.Request.Headers.Authorization!.Parameter);
+
+            Assert.Equal("https://api.sift.com/v3/accounts/" + accountId + "/global_profile/lookup",
+                         globalProfileLookupRequest.Request.RequestUri!.ToString());
+
+            Assert.Equal("{\"email\":\"gary@example.com\",\"phone\":\"+15555550100\"}",
+                         JsonConvert.SerializeObject(globalProfileLookupRequest));
+        }
+
+        [Fact]
+        public void TestGlobalProfileLookupRequestRequiresEmailOrPhone()
+        {
+            var globalProfileLookupRequest = new GlobalProfileLookupRequest
+            {
+                AccountId = "12345678"
+            };
+            globalProfileLookupRequest.ApiKey = "key";
+
+            Assert.Throws<MissingFieldException>(
+                () => globalProfileLookupRequest.Request
+            );
+        }
+
+        [Fact]
+        public void TestGlobalProfileResponseDeserialization()
+        {
+            var json = "{" +
+                "\"status\":0," +
+                "\"error_message\":\"OK\"," +
+                "\"error_code\":null," +
+                "\"lookback_months\":12," +
+                "\"profile_summary\":{" +
+                    "\"identity_found\":true," +
+                    "\"has_links\":true," +
+                    "\"link_count\":7," +
+                    "\"linked_accounts_count_per_industry\":{\"finances\":3,\"internet\":4}" +
+                "}," +
+                "\"identity_age\":{" +
+                    "\"oldest_account_age_timestamp\":1681090536," +
+                    "\"newest_account_age_timestamp\":1881090536," +
+                    "\"average_account_age_timestamp\":1781090536" +
+                "}," +
+                "\"user_decisions\":{" +
+                    "\"total\":12,\"blocked\":2,\"watched\":3,\"accepted\":6," +
+                    "\"manual\":4,\"auto\":8,\"last_type\":\"BLOCK\",\"last_timestamp\":1881090536" +
+                "}," +
+                "\"chargebacks\":{" +
+                    "\"total\":3,\"fraudulent\":2,\"other\":1," +
+                    "\"last_timestamp\":1881090536,\"last_fraudulent_timestamp\":1881090536" +
+                "}," +
+                "\"orders\":{" +
+                    "\"total\":50,\"blocked\":2,\"watched\":5,\"accepted\":40," +
+                    "\"last_timestamp\":1881090536,\"last_blocked_timestamp\":1881090536" +
+                "}," +
+                "\"transactions\":{" +
+                    "\"total\":120,\"failed_fraud\":3,\"failed_other\":5,\"successful\":112," +
+                    "\"last_timestamp\":1881090536,\"last_failed_fraud_timestamp\":1881090536" +
+                "}," +
+                "\"locations\":{" +
+                    "\"unique_billing_addresses\":2,\"unique_shipping_addresses\":4," +
+                    "\"distinct_countries_count\":3,\"distinct_regions_count\":5," +
+                    "\"location_connected_accounts\":[{\"city\":\"Kyiv\",\"country\":\"UA\"}]," +
+                    "\"location_last_used_timestamp\":1881090536" +
+                "}" +
+            "}";
+
+            var response = JsonConvert.DeserializeObject<GlobalProfileResponse>(json);
+
+            Assert.Equal(0, response!.Status);
+            Assert.Equal(12, response.LookbackMonths);
+            Assert.True(response.ProfileSummary!.IdentityFound);
+            Assert.Equal(7, response.ProfileSummary.LinkCount);
+            Assert.Equal(3, response.ProfileSummary.LinkedAccountsCountPerIndustry!["finances"]);
+            Assert.Equal(1681090536, response.IdentityAge!.OldestAccountAgeTimestamp);
+            Assert.Equal(12, response.UserDecisions!.Total);
+            Assert.Equal(3, response.Chargebacks!.Total);
+            Assert.Equal(50, response.Orders!.Total);
+            Assert.Equal(120, response.Transactions!.Total);
+            Assert.Equal(2, response.Locations!.UniqueBillingAddresses);
+            Assert.Single(response.Locations.LocationConnectedAccounts!);
+            Assert.Equal("Kyiv", response.Locations.LocationConnectedAccounts![0].City);
+        }
+
+        [Fact]
+        public void TestGlobalProfileResponseWhenIdentityNotFound()
+        {
+            var json = "{" +
+                "\"status\":0," +
+                "\"error_message\":\"OK\"," +
+                "\"error_code\":null," +
+                "\"lookback_months\":null," +
+                "\"profile_summary\":{" +
+                    "\"identity_found\":false," +
+                    "\"has_links\":false," +
+                    "\"link_count\":0," +
+                    "\"linked_accounts_count_per_industry\":{}" +
+                "}," +
+                "\"identity_age\":null," +
+                "\"user_decisions\":null," +
+                "\"chargebacks\":null," +
+                "\"orders\":null," +
+                "\"transactions\":null," +
+                "\"locations\":null" +
+            "}";
+
+            var response = JsonConvert.DeserializeObject<GlobalProfileResponse>(json);
+
+            Assert.False(response!.ProfileSummary!.IdentityFound);
+            Assert.Null(response.IdentityAge);
+            Assert.Null(response.UserDecisions);
+            Assert.Null(response.Chargebacks);
+            Assert.Null(response.Orders);
+            Assert.Null(response.Transactions);
+            Assert.Null(response.Locations);
+        }
+
+        [Fact]
         public void TestChargebackEvent()
         {
             //Please provide the valid session id in place of 'sessionId'


### PR DESCRIPTION
## Purpose:
- Add client support for the new Global Profile API, which returns cross-tenant identity, decision, chargeback, order, transaction, and location signals for a user
- Expose two new endpoints: `GET /v3/accounts/{accountId}/global_profile/users/{userId}` (lookup by Sift user ID) and `POST /v3/accounts/{accountId}/global_profile/lookup` (lookup by email and/or phone)

## Technical overview:
- `GlobalProfileRequest` — GET endpoint; takes `AccountId`, `UserId`, and optional `GlobalOnly` (`bool?`) and `IncludeOwnData` (`bool?`) query params; params are only added to the URL when explicitly set so server-side defaults apply otherwise
- `GlobalProfileLookupRequest` — POST endpoint; takes `AccountId`, `Email`, and `Phone`; throws `MissingFieldException` client-side before the request is built when both `Email` and `Phone` are missing, mirroring the existing required-field validation pattern
- `GlobalProfileResponse : SiftResponse` with nested POCOs for all response fields (`ProfileSummaryJson`, `IdentityAgeJson`, `UserDecisionsJson`, `ChargebacksJson`, `OrdersJson`, `TransactionsJson`, `LocationsJson`, `LocationConnectedAccountJson`); all nested objects and count fields are nullable so `identity_found: false` responses deserialize cleanly
- `Client` gains `SendAsync(GlobalProfileRequest)` and `SendAsync(GlobalProfileLookupRequest)` overloads following the existing `SendAsync<T>` dispatch pattern

## Testing plan:
- [x] This PR contains all required labels and reviewers as per our [Change Management Procedure](https://sift.atlassian.net/wiki/spaces/RNDTEAM/pages/1127712749/Change+Management+Procedure#Making-a-GitHub-Pull-Request)
- Live tested against the Sift API with a real account: both GET and POST returned `status=0, error_message=OK` with `identity_found=True`, `link_count=31`, and fully populated location entries including `city`, `region`, and `country`

## Deployment plan:
- [x] Related documentation is updated
    - `README.md`: new "Global Profile" section with usage examples for both endpoints; version heading bumped to v1.8.0
    - `CHANGES.MD`: new `1.8.0` entry
    - `Sift/Sift.csproj`: version bumped to `1.8.0`

- Merge when Global Profile API is publicly available
- Merge before https://github.com/SiftScience/sift-docs/pull/92

## Rollback plan:
- Revert this PR; no schema changes, no breaking changes to existing methods, fully additive

## Customer Impact Assessment:
- as per our [Change Management Procedure](https://sift.atlassian.net/wiki/spaces/RNDTEAM/pages/1127712749/Change+Management+Procedure#Making-a-GitHub-Pull-Request)